### PR TITLE
fix(mcp): keep stdio server alive after init with server.waiting()

### DIFF
--- a/crates/causal-memory-cli/src/main.rs
+++ b/crates/causal-memory-cli/src/main.rs
@@ -147,10 +147,12 @@ fn run_mcp_server() -> anyhow::Result<()> {
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
         let transport = (tokio::io::stdin(), tokio::io::stdout());
-        server
+        let server = server
             .serve(transport)
             .await
             .map_err(|e| anyhow::anyhow!("MCP server error: {e}"))?;
+        tracing::info!("MCP server initialized; waiting for shutdown");
+        let _ = server.waiting().await;
         tracing::info!("MCP server shut down");
         Ok(())
     })


### PR DESCRIPTION
## Bug: MCP server exits immediately after initialization

### Problem
`run_mcp_server()` called `server.serve(transport).await?` but did **not** call `server.waiting().await` on the returned handle. 

Per the `rmcp` docs, `serve()` completes the initialization handshake and returns a `RunningService` handle. The server process then exits immediately, before any client can call tools.

### Impact
- Any MCP client (VS Code, Claude Desktop, etc.) connecting via stdio would see the server disappear after `initialize`
- `tools/list` and all tool calls were unreachable

### Fix
Capture the handle and block on `server.waiting().await` to keep the server alive until the transport closes.

```rust
let server = server.serve(transport).await?;
let _ = server.waiting().await;
```

### Verification
Tested with a Python MCP JSON-RPC client over stdio:
- ✅ `initialize` → `rmcp v2.2.0`
- ✅ `notifications/initialized` handshake
- ✅ `tools/list` → 4 tools exposed
- ✅ `record_decision` x2 → edges written to SQLite
- ✅ `search_causal` → retrieves by task_tag + query
- ✅ `trace_cause_chain` → multi-hop CTE query works