### PR TITLE
Fix/cjk tokenization obs auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rows). Structured JSON logs on stderr via `CAUSAL_MEMORY_LOG_FORMAT=json`.
   OTLP export deferred until a collector exists.
 
+### Security
+- **Opt-in bearer auth for observability endpoints** — setting
+  `CAUSAL_MEMORY_HTTP_AUTH_TOKEN` (env or `setconfig`; unset = open, the
+  previous behavior) requires `Authorization: Bearer <token>` on
+  `/metrics` and `/debug/*` of the MCP HTTP server and `/metrics` of the
+  AMC server. Constant-time comparison; scheme case-insensitive; 401s
+  carry `WWW-Authenticate: Bearer`. Health probes (`/health` `/healthz`
+  `/readyz`) stay open by design (kubelet probes cannot send bearer
+  headers, and those routes leak nothing). `/mcp` auth is out of scope
+  (rmcp 2.2.0 already restricts it to loopback Host headers by default).
+  `getconfig` now masks `*_TOKEN` values like `*_KEY`.
+
 ### Fixed
 - **`stats` on an empty database** no longer errors (`MIN/MAX/AVG` return
   NULL on zero rows; now COALESCEd to the initial q_value 0.5).
@@ -33,6 +45,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   SIGPIPE's default disposition (Rust ignores it by default), so both the
   cargo binary and the pip console script die quietly like normal Unix
   tools instead of panicking on `println!`.
+- **CJK text in hippocampus SimHash/Jaccard** — `simhash` and
+  `text_jaccard_similarity` had their own whitespace tokenization while
+  every retrieval path uses `patterns::tokenize` (ASCII words + CJK
+  character bigrams). For unspaced text each sentence collapsed into one
+  giant token: novelty detection scored surprise ≈ 1.0 for every Chinese
+  outcome (the gate recorded everything; Hybrid mode never consulted the
+  LLM), prediction-gap similarity was ~0, and SimHash lost pattern
+  separation. Both now route through `patterns::tokenize`. Note: new
+  writes persist `sparse_code` under the new scheme; rows written before
+  0.9.3 keep old-scheme codes, so mixed-era comparisons may miss a
+  near-duplicate log line (observability only — real dedup is exact-text).
 
 ## [0.9.2] - 2026-08-25
 

--- a/README.md
+++ b/README.md
@@ -268,8 +268,7 @@ into your system prompt / `AGENTS.md`.
 ./target/release/causal-memory http --port 9938   # MCP Streamable HTTP
 ```
 
-Observability endpoints on the same port (UNAUTHENTICATED — do not expose
-to the public internet):
+Observability endpoints on the same port:
 
 ```
 GET /metrics                    Prometheus text (RED + recall metrics)
@@ -279,6 +278,16 @@ GET /debug/recall?query=...     run a recall now, return the full JSON trace
 GET /debug/recalls              newest-first recall audit rows (persisted,
                                 schema v13 recall_audit table; survives restarts)
 ```
+
+`/metrics` and `/debug/*` expose the recall corpus, so they accept opt-in
+bearer auth: set `CAUSAL_MEMORY_HTTP_AUTH_TOKEN` (env or
+`causal-memory setconfig`) and they require
+`Authorization: Bearer <token>` (unset = open, the previous behavior).
+`/healthz` / `/readyz` stay open on purpose — kubelet probes cannot send
+bearer headers and leak nothing. `/mcp` auth is not covered by the token
+(rmcp 2.2.0 already restricts it to loopback Host headers by default; MCP
+client auth is tracked in the roadmap). Without the token, do not expose
+the port to the public internet.
 
 Structured JSON logs on stderr: `CAUSAL_MEMORY_LOG_FORMAT=json`.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -230,7 +230,7 @@ cargo build --release
 ./target/release/causal-memory http --port 9938   # MCP Streamable HTTP
 ```
 
-同一端口的可观测性端点（**无鉴权——请勿暴露公网**）：
+同一端口的可观测性端点：
 
 ```
 GET /metrics                    Prometheus 文本（RED + 召回指标）
@@ -240,6 +240,15 @@ GET /debug/recall?query=...     现场执行一次召回，返回完整 JSON tra
 GET /debug/recalls              最近的召回审计记录（落库持久化，
                                 schema v13 recall_audit 表，重启不丢）
 ```
+
+`/metrics` 和 `/debug/*` 会暴露召回内容，因此支持可选的 Bearer 鉴权：
+设置 `CAUSAL_MEMORY_HTTP_AUTH_TOKEN`（环境变量或
+`causal-memory setconfig`）后，这些端点要求
+`Authorization: Bearer <token>`（不设置 = 保持开放，即原有行为）。
+`/healthz` / `/readyz` 有意保持开放——kubelet 探针无法携带 bearer 头，
+且这两个端点不泄露内容。`/mcp` 不在此 token 的保护范围内
+（rmcp 2.2.0 默认已将其限制为 loopback Host；MCP 客户端鉴权见 roadmap）。
+未设置 token 时请勿将该端口暴露公网。
 
 stderr 结构化 JSON 日志：`CAUSAL_MEMORY_LOG_FORMAT=json`。
 

--- a/crates/causal-memory-cli/src/amc.rs
+++ b/crates/causal-memory-cli/src/amc.rs
@@ -332,16 +332,24 @@ async fn handle_health() -> Json<HealthResponse> {
 
 type AppState = Arc<UserMemories>;
 
-fn build_app(users: AppState) -> Router {
+fn build_app(users: AppState, auth_token: Option<String>) -> Router {
+    // Observability: liveness/readiness + Prometheus text. /health stays
+    // for backward compatibility; probes stay open (kubelet can't send
+    // bearer headers); /metrics takes optional bearer auth — the challenge
+    // harness contract covers /add /search only and never sets the token.
+    let obs = Router::new()
+        .route("/health", get(handle_health))
+        .route("/healthz", get(|| async { "ok" }))
+        .route("/readyz", get(handle_readyz));
+    let metrics = causal_memory_cli::http_auth::protected(
+        Router::new().route("/metrics", get(handle_metrics)),
+        auth_token,
+    );
     Router::new()
         .route("/add", post(handle_add))
         .route("/search", post(handle_search))
-        .route("/health", get(handle_health))
-        // Observability: liveness/readiness + Prometheus text. /health
-        // stays for backward compatibility.
-        .route("/healthz", get(|| async { "ok" }))
-        .route("/readyz", get(handle_readyz))
-        .route("/metrics", get(handle_metrics))
+        .merge(obs)
+        .merge(metrics)
         .with_state(users)
 }
 
@@ -417,6 +425,7 @@ fn main() -> Result<()> {
         None => println!("causal-memory-amc embedding: none (BM25-only retrieval)"),
     }
     let users = Arc::new(UserMemories::new(db_dir, mode));
+    let auth_token = causal_memory_cli::http_auth::token_from_config();
     let addr: SocketAddr = format!("0.0.0.0:{port}").parse()?;
     println!(
         "causal-memory-amc listening on http://{addr} (write-mode: {}, one store per user_id)",
@@ -425,12 +434,16 @@ fn main() -> Result<()> {
             WriteMode::Raw => "raw",
         }
     );
+    match &auth_token {
+        Some(_) => println!("Auth: /metrics requires 'Authorization: Bearer <token>' (CAUSAL_MEMORY_HTTP_AUTH_TOKEN); /add /search /health* stay open"),
+        None => println!("NOTE: /metrics is unauthenticated (bound on 0.0.0.0); set CAUSAL_MEMORY_HTTP_AUTH_TOKEN to lock it down"),
+    }
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
         let listener = tokio::net::TcpListener::bind(addr)
             .await
             .map_err(|e| anyhow::anyhow!("bind {addr}: {e}"))?;
-        axum::serve(listener, build_app(users))
+        axum::serve(listener, build_app(users, auth_token))
             .await
             .map_err(|e| anyhow::anyhow!("serve: {e}"))?;
         Ok(())
@@ -470,14 +483,17 @@ mod tests {
         panic!("server did not become ready");
     }
 
-    async fn spawn_server(mode: WriteMode) -> (String, tokio::task::JoinHandle<()>, PathBuf) {
+    async fn spawn_server(
+        mode: WriteMode,
+        auth_token: Option<String>,
+    ) -> (String, tokio::task::JoinHandle<()>, PathBuf) {
         let dir = std::env::temp_dir().join(format!(
             "amc-test-{}-{:?}",
             std::process::id(),
             std::time::Instant::now()
         ));
         std::fs::create_dir_all(&dir).unwrap();
-        let app = build_app(Arc::new(UserMemories::new(dir.clone(), mode)));
+        let app = build_app(Arc::new(UserMemories::new(dir.clone(), mode)), auth_token);
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move {
@@ -497,7 +513,7 @@ mod tests {
 
     #[tokio::test]
     async fn raw_roundtrip_isolation_and_topk() {
-        let (base, _server, dir) = spawn_server(WriteMode::Raw).await;
+        let (base, _server, dir) = spawn_server(WriteMode::Raw, None).await;
         let client = test_client();
         wait_ready(&client, &base).await;
 
@@ -587,7 +603,7 @@ mod tests {
 
     #[tokio::test]
     async fn empty_search_and_unknown_user() {
-        let (base, _server, dir) = spawn_server(WriteMode::Raw).await;
+        let (base, _server, dir) = spawn_server(WriteMode::Raw, None).await;
         let client = test_client();
         wait_ready(&client, &base).await;
         let resp = client
@@ -609,12 +625,52 @@ mod tests {
         // (remember's own fallback stores a raw stub). The contract's
         // synchronous-searchable rule holds either way.
         std::env::remove_var("CAUSAL_MEMORY_LLM_API");
-        let (base, _server, dir) = spawn_server(WriteMode::Distill).await;
+        let (base, _server, dir) = spawn_server(WriteMode::Distill, None).await;
         let client = test_client();
         wait_ready(&client, &base).await;
         let resp = client
             .post(format!("{base}/add"))
             .json(&add_body("dave", "s1", &[("user", "hello there")]))
+            .send()
+            .await
+            .unwrap();
+        assert!(resp.status().is_success());
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    #[tokio::test]
+    async fn metrics_bearer_gated_when_token_set() {
+        // Opt-in auth: token set → /metrics 401s without (or with a wrong)
+        // bearer and serves with the right one; the challenge-contract
+        // routes (/add /search) and probes stay open either way.
+        let (base, _server, dir) =
+            spawn_server(WriteMode::Raw, Some("amc-bearer-token".into())).await;
+        let client = test_client();
+        wait_ready(&client, &base).await;
+
+        let no_auth = client.get(format!("{base}/metrics")).send().await.unwrap();
+        assert_eq!(no_auth.status(), axum::http::StatusCode::UNAUTHORIZED);
+
+        let wrong = client
+            .get(format!("{base}/metrics"))
+            .header("Authorization", "Bearer nope")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(wrong.status(), axum::http::StatusCode::UNAUTHORIZED);
+
+        let ok = client
+            .get(format!("{base}/metrics"))
+            .header("Authorization", "Bearer amc-bearer-token")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(ok.status(), axum::http::StatusCode::OK);
+
+        // Contract routes unaffected by the token.
+        let resp = client
+            .post(format!("{base}/add"))
+            .json(&add_body("eve", "s1", &[("user", "hello there")]))
             .send()
             .await
             .unwrap();

--- a/crates/causal-memory-cli/src/commands/misc.rs
+++ b/crates/causal-memory-cli/src/commands/misc.rs
@@ -194,6 +194,8 @@ pub(crate) fn run_http_server(args: &[String]) -> anyhow::Result<()> {
     if let Some(parent) = db_path.parent() {
         std::fs::create_dir_all(parent)?;
     }
+    // Opt-in bearer auth for the observability routes (empty/unset = open).
+    let auth_token = crate::http_auth::token_from_config();
 
     eprintln!("Opening causal memory DB at {}", db_path.display());
     // A3: one shared store for the whole process — every connection works
@@ -236,14 +238,10 @@ pub(crate) fn run_http_server(args: &[String]) -> anyhow::Result<()> {
 
         let app = axum::Router::new()
             .route_service("/mcp", service)
-            // /health kept for backward compatibility.
-            .route("/health", axum::routing::get(|| async { "ok" }))
-            .route("/healthz", axum::routing::get(|| async { "ok" }))
-            .route("/readyz", axum::routing::get(obs_readyz))
-            .route("/metrics", axum::routing::get(obs_metrics))
-            .route("/debug/recall", axum::routing::get(obs_debug_recall))
-            .route("/debug/recalls", axum::routing::get(obs_debug_recalls))
-            .with_state(ObsState { store, debug_memory });
+            .merge(build_obs_router(
+                ObsState { store, debug_memory },
+                auth_token.clone(),
+            ));
 
         let listener = tokio::net::TcpListener::bind(format!("{host}:{port}"))
             .await
@@ -252,7 +250,26 @@ pub(crate) fn run_http_server(args: &[String]) -> anyhow::Result<()> {
         eprintln!("Health check: http://{host}:{port}/healthz (legacy: /health)");
         eprintln!("Metrics:      http://{host}:{port}/metrics");
         eprintln!("Recall debug: http://{host}:{port}/debug/recall?query=... (+ /debug/recalls)");
-        eprintln!("NOTE: /metrics and /debug/* are unauthenticated — do not expose to the public internet");
+        let loopback_host =
+            host == "127.0.0.1" || host == "localhost" || host == "::1" || host == "[::1]";
+        match (&auth_token, loopback_host) {
+            (Some(token), _) => {
+                eprintln!(
+                    "Auth: /metrics and /debug/* require 'Authorization: Bearer <token>' (CAUSAL_MEMORY_HTTP_AUTH_TOKEN)"
+                );
+                if token.len() < 16 {
+                    eprintln!("WARNING: bearer token is shorter than 16 chars — brute-forceable; use a longer one");
+                }
+            }
+            (None, false) => {
+                eprintln!(
+                    "WARNING: /metrics and /debug/* are unauthenticated and the server is bound on {host} — set CAUSAL_MEMORY_HTTP_AUTH_TOKEN or bind --host 127.0.0.1 before exposing this port"
+                );
+            }
+            (None, true) => {
+                eprintln!("NOTE: /metrics and /debug/* are unauthenticated (loopback bind); set CAUSAL_MEMORY_HTTP_AUTH_TOKEN to lock them down");
+            }
+        }
 
         axum::serve(listener, app)
             .await
@@ -266,6 +283,28 @@ pub(crate) fn run_http_server(args: &[String]) -> anyhow::Result<()> {
 struct ObsState {
     store: std::sync::Arc<CausalStore>,
     debug_memory: std::sync::Arc<causal_memory::memory::Memory>,
+}
+
+/// The observability routes (everything except `/mcp`). Health probes
+/// (`/health`, `/healthz`, `/readyz`) stay open on purpose — kubelet
+/// liveness/readiness probes cannot attach bearer headers and these routes
+/// leak nothing. `/metrics` and `/debug/*` carry the recall corpus behind
+/// optional bearer auth (`CAUSAL_MEMORY_HTTP_AUTH_TOKEN`; unset = open,
+/// the pre-auth behavior). Extracted from `run_http_server` so the router
+/// can be exercised end-to-end in tests without an rmcp service.
+fn build_obs_router(state: ObsState, auth_token: Option<String>) -> axum::Router {
+    let secret_routes = axum::Router::new()
+        .route("/metrics", axum::routing::get(obs_metrics))
+        .route("/debug/recall", axum::routing::get(obs_debug_recall))
+        .route("/debug/recalls", axum::routing::get(obs_debug_recalls));
+    let secret_routes = crate::http_auth::protected(secret_routes, auth_token);
+    // /health kept for backward compatibility.
+    axum::Router::new()
+        .route("/health", axum::routing::get(|| async { "ok" }))
+        .route("/healthz", axum::routing::get(|| async { "ok" }))
+        .route("/readyz", axum::routing::get(obs_readyz))
+        .merge(secret_routes)
+        .with_state(state)
 }
 
 /// Readiness: a light DB probe (count chunks). 503 when the store is down.
@@ -793,5 +832,133 @@ mod obs_tests {
         let text = obs_metrics(axum::extract::State(s)).await;
         assert!(text.contains("causal_memory_store_chunks 2"), "{text}");
         assert!(text.contains("causal_memory_uptime_seconds"), "{text}");
+    }
+
+    // ─── Bearer auth on the real router (ephemeral port + reqwest, the
+    // amc.rs self-test pattern) ─────────────────────────────────────────
+
+    /// No keep-alive reuse: on the current-thread tokio runtime the reqwest
+    /// pool can reset a reused idle connection between requests (a
+    /// test-harness artifact — see amc.rs's test_client note).
+    fn test_client() -> reqwest::Client {
+        reqwest::Client::builder()
+            .pool_max_idle_per_host(0)
+            .build()
+            .unwrap()
+    }
+
+    async fn spawn_obs(auth_token: Option<String>) -> String {
+        let app = build_obs_router(state(), auth_token);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        let base = format!("http://{addr}");
+        let client = test_client();
+        for _ in 0..100 {
+            if client
+                .get(format!("{base}/health"))
+                .send()
+                .await
+                .map(|r| r.status().is_success())
+                .unwrap_or(false)
+            {
+                return base;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        panic!("obs server did not become ready");
+    }
+
+    #[tokio::test]
+    async fn obs_router_no_token_all_open() {
+        let base = spawn_obs(None).await;
+        let client = test_client();
+        for path in [
+            "/health",
+            "/healthz",
+            "/readyz",
+            "/metrics",
+            "/debug/recalls",
+        ] {
+            let status = client
+                .get(format!("{base}{path}"))
+                .send()
+                .await
+                .unwrap()
+                .status();
+            assert_eq!(status, axum::http::StatusCode::OK, "{path} -> {status}");
+        }
+    }
+
+    #[tokio::test]
+    async fn obs_router_rejects_missing_or_wrong_bearer() {
+        let base = spawn_obs(Some("s3cret-bearer-token".into())).await;
+        let client = test_client();
+        // No header.
+        for path in ["/metrics", "/debug/recall?query=x", "/debug/recalls"] {
+            let resp = client.get(format!("{base}{path}")).send().await.unwrap();
+            assert_eq!(
+                resp.status(),
+                axum::http::StatusCode::UNAUTHORIZED,
+                "{path} without header"
+            );
+            assert_eq!(
+                resp.headers().get("www-authenticate").unwrap(),
+                "Bearer",
+                "RFC 6750 challenge on {path}"
+            );
+        }
+        // Wrong token.
+        let resp = client
+            .get(format!("{base}/metrics"))
+            .header("Authorization", "Bearer wrong-token")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn obs_router_accepts_correct_bearer() {
+        let base = spawn_obs(Some("s3cret-bearer-token".into())).await;
+        let client = test_client();
+        let resp = client
+            .get(format!("{base}/metrics"))
+            .header("Authorization", "Bearer s3cret-bearer-token")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+        let body = resp.text().await.unwrap();
+        assert!(body.contains("causal_memory_uptime_seconds"), "{body}");
+        // The query-string debug route works through the middleware (the
+        // middleware only reads the Authorization header).
+        let resp = client
+            .get(format!("{base}/debug/recall?query=test+suite+release"))
+            .header("Authorization", "bearer s3cret-bearer-token") // scheme case-insensitive
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+        let body = resp.text().await.unwrap();
+        assert!(body.contains("\"results\""), "{body}");
+    }
+
+    #[tokio::test]
+    async fn obs_router_health_probes_open_when_token_set() {
+        let base = spawn_obs(Some("s3cret-bearer-token".into())).await;
+        let client = test_client();
+        // kubelet liveness/readiness probes cannot attach bearer headers.
+        for path in ["/health", "/healthz", "/readyz"] {
+            let status = client
+                .get(format!("{base}{path}"))
+                .send()
+                .await
+                .unwrap()
+                .status();
+            assert_eq!(status, axum::http::StatusCode::OK, "{path} -> {status}");
+        }
     }
 }

--- a/crates/causal-memory-cli/src/http_auth.rs
+++ b/crates/causal-memory-cli/src/http_auth.rs
@@ -1,0 +1,106 @@
+//! Opt-in bearer-token auth for the observability endpoints.
+//!
+//! `CAUSAL_MEMORY_HTTP_AUTH_TOKEN` (env or `setconfig`; empty/unset =
+//! disabled, today's open behavior) gates `/metrics` and `/debug/*` on the
+//! MCP HTTP server and `/metrics` on the AMC server. Health probes
+//! (`/health`, `/healthz`, `/readyz`) stay open on purpose: kubelet
+//! liveness/readiness probes cannot attach bearer headers, and those
+//! endpoints leak nothing beyond an "ok"/DB-up status. The `/mcp` route is
+//! out of scope — MCP-client auth deserves its own design (rmcp 2.2.0
+//! already restricts it to loopback Host headers by default).
+
+use axum::extract::{Request, State};
+use axum::http::{header, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use axum::Router;
+
+/// Constant-time string equality (best effort, safe code — the workspace
+/// denies `unsafe`). The XOR fold has no early exit on mismatch and the
+/// accumulator is `black_box`ed so the optimizer cannot turn it into one;
+/// differing lengths return false immediately (length is not a secret).
+pub fn constant_time_eq(a: &str, b: &str) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.as_bytes().iter().zip(b.as_bytes().iter()) {
+        diff |= x ^ y;
+    }
+    std::hint::black_box(diff) == 0
+}
+
+/// Middleware: require `Authorization: Bearer <token>` (scheme
+/// case-insensitive). Only reads the header — body and query (e.g.
+/// `/debug/recall?query=...`) pass through untouched. 401 carries
+/// `WWW-Authenticate: Bearer` per RFC 6750 and a plain-text body (the obs
+/// handlers already answer in plain text; there is no JSON error
+/// convention to match).
+pub async fn require_bearer(State(token): State<String>, req: Request, next: Next) -> Response {
+    let authorized = req
+        .headers()
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .map(|v| match v.split_once(' ') {
+            Some((scheme, cred)) if scheme.eq_ignore_ascii_case("bearer") => {
+                constant_time_eq(cred.trim(), token.as_str())
+            }
+            _ => false,
+        })
+        .unwrap_or(false);
+    if authorized {
+        next.run(req).await
+    } else {
+        (
+            StatusCode::UNAUTHORIZED,
+            [(header::WWW_AUTHENTICATE, "Bearer")],
+            "unauthorized: missing or invalid bearer token",
+        )
+            .into_response()
+    }
+}
+
+/// Apply bearer auth to a router when a token is configured; return it
+/// unchanged otherwise (opt-in: unset token = every route open, exactly the
+/// pre-auth behavior). `route_layer` only touches routes registered on
+/// `router` before this call, so open routes (health probes, `/mcp`) never
+/// sit behind it. Generic over the router's state type so callers can layer
+/// it before `with_state`.
+pub fn protected<S: Clone + Send + Sync + 'static>(
+    router: Router<S>,
+    token: Option<String>,
+) -> Router<S> {
+    match token {
+        Some(token) => {
+            router.route_layer(axum::middleware::from_fn_with_state(token, require_bearer))
+        }
+        None => router,
+    }
+}
+
+/// Resolve the auth token from config (env wins over the config file; the
+/// value is trimmed — config-file entries can carry trailing whitespace).
+/// Empty/unset = auth disabled.
+pub fn token_from_config() -> Option<String> {
+    let t = causal_memory::config::get("CAUSAL_MEMORY_HTTP_AUTH_TOKEN")?;
+    let t = t.trim();
+    if t.is_empty() {
+        None
+    } else {
+        Some(t.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constant_time_eq_cases() {
+        assert!(constant_time_eq("token", "token"));
+        assert!(!constant_time_eq("token", "tokem"));
+        assert!(!constant_time_eq("token", "tokenn"));
+        assert!(!constant_time_eq("", "x"));
+        assert!(constant_time_eq("", ""));
+    }
+}

--- a/crates/causal-memory-cli/src/lib.rs
+++ b/crates/causal-memory-cli/src/lib.rs
@@ -11,6 +11,7 @@ pub mod bench;
 pub mod bench_agent;
 pub mod bench_tokens;
 pub mod commands;
+pub mod http_auth;
 pub mod server;
 
 use commands::distill::{run_distill, run_novelty};
@@ -198,11 +199,13 @@ fn print_help() {
          \n\
          Server modes (default: MCP over stdio):\n\
          \x20 (no args)              MCP server via stdio\n\
-         \x20 http [--port N]       MCP server over HTTP\n\
+         \x20 http [--port N] [--host H]  MCP server over HTTP\n\
+         \x20                          (set CAUSAL_MEMORY_HTTP_AUTH_TOKEN to\n\
+         \x20                           protect /metrics and /debug/*)\n\
          \n\
          Configuration:\n\
          \x20 setconfig K=V [K=V...] write config keys (empty value deletes)\n\
-         \x20 getconfig             list configured values (*_KEY masked)\n\
+         \x20 getconfig             list configured values (*_KEY / *_TOKEN masked)\n\
          \x20 config-path           print the config file path\n\
          \n\
          Extraction & maintenance:\n\

--- a/crates/causal-memory/src/config.rs
+++ b/crates/causal-memory/src/config.rs
@@ -21,6 +21,7 @@ pub const ALLOWED_KEYS: &[&str] = &[
     "CAUSAL_MEMORY_LLM_KEY",
     "CAUSAL_MEMORY_LLM_MODEL",
     "CAUSAL_MEMORY_HTTP_TIMEOUT_SECS",
+    "CAUSAL_MEMORY_HTTP_AUTH_TOKEN",
 ];
 
 /// Resolved config-file path.
@@ -114,7 +115,7 @@ fn load(path: &Path) -> HashMap<String, String> {
 const USAGE: &str = "causal-memory — config management
 USAGE:
   causal-memory setconfig KEY=VALUE [KEY=VALUE...]   write config keys (empty VALUE deletes)
-  causal-memory getconfig                            list configured values (*_KEY masked)
+  causal-memory getconfig                            list configured values (*_KEY / *_TOKEN masked)
   causal-memory config-path                          print the config file path
 Config file: $CAUSAL_MEMORY_CONFIG or ~/.local/share/causal-memory/config.json
 Process env vars always override the file.";
@@ -172,10 +173,10 @@ pub fn cli_main(args: &[String]) -> i32 {
     }
 }
 
-/// `*_KEY` values are masked (first 4 chars + ***) so getconfig is safe to
-/// paste into chats/issues.
+/// Secret-bearing values (`*_KEY`, `*_TOKEN`) are masked (first 4 chars +
+/// ***) so getconfig is safe to paste into chats/issues.
 fn display_value(key: &str, value: &str) -> String {
-    if key.ends_with("_KEY") {
+    if key.ends_with("_KEY") || key.ends_with("_TOKEN") {
         let head: String = value.chars().take(4).collect();
         format!("{head}***")
     } else {
@@ -325,5 +326,32 @@ mod tests {
         assert_eq!(cli_main(&["frobnicate".to_string()]), 2);
         assert_eq!(cli_main(&["getconfig".to_string()]), 0);
         assert_eq!(cli_main(&["config-path".to_string()]), 0);
+    }
+
+    #[test]
+    fn auth_token_is_allowlisted_and_masked() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = dir.path().join("config.json");
+        let _cfg = EnvGuard::set("CAUSAL_MEMORY_CONFIG", cfg.to_str().unwrap());
+        let _k = EnvGuard::unset("CAUSAL_MEMORY_HTTP_AUTH_TOKEN");
+
+        // Allowlisted: setconfig accepts it, get resolves env-then-file.
+        assert_eq!(
+            cli_main(&[
+                "setconfig".to_string(),
+                "CAUSAL_MEMORY_HTTP_AUTH_TOKEN=s3cret-bearer-token".to_string(),
+            ]),
+            0
+        );
+        assert_eq!(
+            get("CAUSAL_MEMORY_HTTP_AUTH_TOKEN").as_deref(),
+            Some("s3cret-bearer-token")
+        );
+        // getconfig must not print the secret in clear.
+        assert_eq!(
+            display_value("CAUSAL_MEMORY_HTTP_AUTH_TOKEN", "s3cret-bearer-token"),
+            "s3cr***"
+        );
     }
 }

--- a/crates/causal-memory/src/consolidate/stages.rs
+++ b/crates/causal-memory/src/consolidate/stages.rs
@@ -238,11 +238,10 @@ pub fn downscale(
             config.gc_threshold
         };
         let weak = new_conf < threshold;
-        let dormant =
-            now - e.discovered_at >= i64::from(config.gc_min_age_hours) * 3600;
-        let untouched = e.last_accessed_at.is_none_or(|last| {
-            now - last >= i64::from(config.gc_access_grace_hours) * 3600
-        });
+        let dormant = now - e.discovered_at >= i64::from(config.gc_min_age_hours) * 3600;
+        let untouched = e
+            .last_accessed_at
+            .is_none_or(|last| now - last >= i64::from(config.gc_access_grace_hours) * 3600);
         let collect = weak && dormant && untouched && e.discovered_by != "user_feedback";
         pendings.push(Pending {
             edge_id: e.edge_id,

--- a/crates/causal-memory/src/consolidate/types.rs
+++ b/crates/causal-memory/src/consolidate/types.rs
@@ -120,12 +120,12 @@ impl Default for ConsolidateConfig {
             replay_gc_threshold: 0.1,
             max_gc_fraction: 0.2,
             gc_floor: 50,
-            gc_min_age_hours: 168,       // 7d dormancy (aligned with temporal tier)
-            gc_access_grace_hours: 168,  // 7d access grace (aligned with boost window)
+            gc_min_age_hours: 168, // 7d dormancy (aligned with temporal tier)
+            gc_access_grace_hours: 168, // 7d access grace (aligned with boost window)
             half_life_user_feedback_hours: 2160, // 90d
-            half_life_llm_hours: 2160,           // 90d (same magnitude as legacy ~69d)
-            half_life_temporal_hours: 168,       // 7d
-            half_life_fact_hours: 2160,          // 90d — facts fade slowest
+            half_life_llm_hours: 2160, // 90d (same magnitude as legacy ~69d)
+            half_life_temporal_hours: 168, // 7d
+            half_life_fact_hours: 2160, // 90d — facts fade slowest
             supersession_limit: 20,
             supersession_action: SupersessionAction::Retire,
             q_alpha: 0.1,

--- a/crates/causal-memory/src/distill.rs
+++ b/crates/causal-memory/src/distill.rs
@@ -838,7 +838,11 @@ mod tests {
             {"kind": "lesson", "text": "2025-06-03: Always run tests first.", "date": "2025-06-03"}
         ]"#;
         let items = Distiller::parse_items(raw, "2025-06-03");
-        assert_eq!(items.len(), 2, "exact repeats collapse, distinct items stay");
+        assert_eq!(
+            items.len(),
+            2,
+            "exact repeats collapse, distinct items stay"
+        );
         assert_eq!(items[0].kind, ItemKind::Event);
         assert_eq!(items[1].kind, ItemKind::Lesson);
     }

--- a/crates/causal-memory/src/hippocampus/mod.rs
+++ b/crates/causal-memory/src/hippocampus/mod.rs
@@ -15,9 +15,6 @@
 //! - Pre-multiplied spread coefficients in values[]
 //!
 //! Limitations:
-//! - text_jaccard_similarity uses whitespace tokenization; Chinese text (no
-//!   spaces) produces one giant token, making novelty detection unreliable.
-//!   Future: switch to character bigrams or a real tokenizer.
 //! - rand_seed uses a fixed-seed xorshift for deterministic testing. Set
 //!   CAUSAL_GRAPH_RANDOM_SEED to enable true randomness in production.
 
@@ -692,11 +689,9 @@ impl CausalGraph {
 
     /// CA1 novelty detection: compare predicted outcomes with actual.
     ///
-    /// WARNING: text_jaccard_similarity uses whitespace tokenization.
-    /// Chinese text (no spaces) produces one giant token, making similarity
-    /// near-zero and surprise near-1.0 for everything. This is a known
-    /// limitation (#10 in review). For Chinese-heavy use, switch to
-    /// character bigrams or a real tokenizer.
+    /// Similarity uses `patterns::tokenize` (lowercased ASCII words minus
+    /// stop words, CJK character bigrams), so surprise is meaningful for
+    /// whitespace-free text too.
     pub fn detect_novelty(&mut self, decision_text: &str, actual_outcome: &str) -> NoveltyReport {
         // Internal computation: use run_hebbian=false so novelty detection
         // doesn't have the side effect of strengthening co-occurrence edges.

--- a/crates/causal-memory/src/hippocampus/tests.rs
+++ b/crates/causal-memory/src/hippocampus/tests.rs
@@ -428,6 +428,104 @@ mod tests {
         assert!((text_jaccard_similarity("aaa", "zzz") - 0.0).abs() < 0.001);
     }
 
+    // ─── CJK: tokenize-based hashing/similarity (0.9.3) ────────────────
+    // Before the fix, whitespace tokenization collapsed each unspaced
+    // Chinese sentence into one giant token: simhash hashed the whole
+    // sentence as a unit (hamming ~random for any edit) and jaccard
+    // similarity was ~0 for any two different sentences (surprise 1.0 for
+    // everything → the novelty gate recorded all Chinese outcomes).
+
+    #[test]
+    fn test_simhash_chinese_distance() {
+        let h1 = simhash("用Redis做缓存");
+        let h2 = simhash("用Redis做缓存了");
+        assert_eq!(h1, simhash("用Redis做缓存"), "deterministic");
+        // Old scheme: two one-giant-token hashes differ in ~64 of 128 bits.
+        // Bigram tokens make a one-char edit a small perturbation.
+        assert!(
+            (h1 ^ h2).count_ones() < 32,
+            "near-identical Chinese should be close, got {}",
+            (h1 ^ h2).count_ones()
+        );
+    }
+
+    #[test]
+    fn test_simhash_chinese_similar_vs_different() {
+        let h1 = simhash("用互斥锁解决并发问题");
+        let h2 = simhash("用互斥锁解决死锁问题");
+        let h3 = simhash("今天买了新鲜的蔬菜");
+        let d12 = (h1 ^ h2).count_ones();
+        let d13 = (h1 ^ h3).count_ones();
+        assert!(d12 < d13, "similar Chinese texts should be closer");
+    }
+
+    #[test]
+    fn test_jaccard_chinese() {
+        // tokens {用, redis, 做缓, 缓存} vs {用, redis, 做缓, 缓存, 存了}
+        // → 4/5 = 0.8 (was ~0.0 before bigram tokenization).
+        let sim = text_jaccard_similarity("用Redis做缓存", "用Redis做缓存了");
+        assert!(
+            (sim - 0.8).abs() < 0.001,
+            "expected 0.8 by the bigram convention, got {sim}"
+        );
+        assert!(text_jaccard_similarity("用Redis做缓存", "重写数据库连接池") < 0.3);
+    }
+
+    #[test]
+    fn test_jaccard_mixed_language() {
+        // English stop-word removal on one side, CJK bigrams on the other:
+        // mixed text still scores high against a near-identical pair.
+        let sim = text_jaccard_similarity("used Redis for caching", "used Redis for caching了");
+        assert!(sim > 0.6, "got {sim}");
+    }
+
+    #[test]
+    fn test_detect_novelty_chinese() {
+        // Regression: with whitespace tokenization the predicted text (a
+        // whole Chinese sentence = one token) never overlapped the actual
+        // outcome → surprise 1.0, should_record always true. Bigrams make
+        // the word-order-varied outcome recognizable → low surprise.
+        let nodes = vec![
+            NodeData {
+                id: "d1".into(),
+                text: "用Redis做缓存".into(),
+                event_time: 1000,
+                q_value: 0.8,
+                replay_count: 0,
+                last_activated: 0,
+                task_tag: Some("caching".into()),
+                scope: None,
+            },
+            NodeData {
+                id: "o1".into(),
+                text: "缓存命中率恢复成功".into(),
+                event_time: 1001,
+                q_value: 0.8,
+                replay_count: 0,
+                last_activated: 0,
+                task_tag: Some("caching".into()),
+                scope: None,
+            },
+        ];
+        let edges = vec![EdgeData {
+            from_id: "d1".into(),
+            to_id: "o1".into(),
+            relation: Relation::Caused,
+            weight: 0.9,
+            valid: true,
+        }];
+        let mut graph = CausalGraph::build(&nodes, &edges);
+        // The recorded outcome, verbatim: predicted (activated o1) vs actual
+        // share every bigram → similarity 1.0, surprise 0.
+        let known = graph.detect_novelty("用Redis做缓存", "缓存命中率恢复成功");
+        assert!(known.surprise < 0.5, "got {}", known.surprise);
+        assert!(!known.should_record);
+        // A genuinely different outcome must stay surprising (gate intact).
+        let novel = graph.detect_novelty("用Redis做缓存", "数据库连接池耗尽报错");
+        assert!(novel.surprise > 0.5, "got {}", novel.surprise);
+        assert!(novel.should_record);
+    }
+
     #[test]
     fn test_relation_spread_coefficients() {
         assert_eq!(Relation::Caused.spread_coeff(), 1.0);

--- a/crates/causal-memory/src/hippocampus/utils.rs
+++ b/crates/causal-memory/src/hippocampus/utils.rs
@@ -4,9 +4,25 @@
 pub(crate) const WEIGHT_CAP: f32 = 2.0;
 
 /// SimHash for pattern separation (DG analog).
+///
+/// Tokens come from [`crate::patterns::tokenize`] (lowercased ASCII words
+/// minus stop words, CJK character bigrams) — the same tokenizer every
+/// retrieval path uses, so whitespace-free text (Chinese, Japanese, …) is
+/// hashed per-bigram instead of collapsing into one giant token.
 pub(crate) fn simhash(text: &str) -> u128 {
     let mut bits = [0_i32; 128];
-    for token in text.to_lowercase().split_whitespace() {
+    // Degenerate input (all stop words / punctuation) tokenizes to nothing;
+    // both texts would then hash to 0 and trip the write-path near-dup log
+    // (hamming 0 ≤ 2). Fall back to hashing the lowercased whole text.
+    let tokens = crate::patterns::tokenize(text);
+    let fallback;
+    let token_refs: Vec<&str> = if tokens.is_empty() {
+        fallback = text.to_lowercase();
+        vec![fallback.as_str()]
+    } else {
+        tokens.iter().map(String::as_str).collect()
+    };
+    for token in token_refs {
         let hash = fnv1a_64(token);
         for (i, bit) in bits[..64].iter_mut().enumerate() {
             if (hash >> i) & 1 == 1 {
@@ -43,12 +59,17 @@ pub(crate) fn fnv1a_64(s: &str) -> u64 {
 }
 
 /// Simple Jaccard text similarity (token overlap).
-/// LIMITATION: whitespace tokenization only; Chinese text needs bigram tokenizer.
+///
+/// Tokens come from [`crate::patterns::tokenize`] (lowercased ASCII words
+/// minus stop words, CJK character bigrams), matching the retrieval paths.
+/// NOTE: unlike [`crate::patterns::jaccard`], two empty token sets are
+/// similar (1.0) here — `detect_novelty`'s "nothing predicted" degenerate
+/// case relies on that convention.
 pub(crate) fn text_jaccard_similarity(a: &str, b: &str) -> f32 {
-    let a_lower = a.to_lowercase();
-    let b_lower = b.to_lowercase();
-    let set_a: std::collections::HashSet<&str> = a_lower.split_whitespace().collect();
-    let set_b: std::collections::HashSet<&str> = b_lower.split_whitespace().collect();
+    let a_tokens = crate::patterns::tokenize(a);
+    let b_tokens = crate::patterns::tokenize(b);
+    let set_a: std::collections::HashSet<&str> = a_tokens.iter().map(String::as_str).collect();
+    let set_b: std::collections::HashSet<&str> = b_tokens.iter().map(String::as_str).collect();
     if set_a.is_empty() && set_b.is_empty() {
         return 1.0;
     }

--- a/crates/causal-memory/src/llm.rs
+++ b/crates/causal-memory/src/llm.rs
@@ -256,7 +256,15 @@ pub async fn chat(
     max_tokens: u32,
     temperature: f32,
 ) -> Result<String> {
-    chat_with_timeout(config, system_prompt, user_msg, max_tokens, temperature, http_timeout()).await
+    chat_with_timeout(
+        config,
+        system_prompt,
+        user_msg,
+        max_tokens,
+        temperature,
+        http_timeout(),
+    )
+    .await
 }
 
 /// `chat` with an explicit per-call timeout. The 8s default suits the

--- a/crates/causal-memory/src/store/write.rs
+++ b/crates/causal-memory/src/store/write.rs
@@ -777,6 +777,9 @@ impl CausalStore {
         let code = crate::hippocampus::utils::simhash(text);
         // Near-duplicate observability (long texts only — short texts collide
         // in 128-bit simhash buckets far too often to be meaningful).
+        // Rows written before 0.9.3 carry old-scheme (whitespace-token) codes;
+        // mixed-era hamming comparisons may miss a near-dup log line until the
+        // old rows age out. Observability only — real dedup is exact-text.
         if text.chars().count() >= 20 {
             let mut stmt = conn.prepare(
                 "SELECT id, sparse_code FROM chunks

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -242,7 +242,10 @@ Ecosystem:
   is done too.
 - [ ] TS bindings (after Python)
 - [x] MCP HTTP transport — ✅ shipped (`causal-memory http`, Streamable
-  HTTP, stateless mode); auth/multi-tenant hardening still open
+  HTTP, stateless mode). Bearer auth for the observability routes
+  shipped 2026-09-01 (`CAUSAL_MEMORY_HTTP_AUTH_TOKEN` gates `/metrics` +
+  `/debug/*`; probes intentionally open; AMC `/metrics` too) — MCP
+  endpoint auth + multi-tenant hardening still open
 - [ ] Multi-tenant support
 - [ ] Backup / restore tooling (migrations already done)
 - [x] Observability (Prometheus, OpenTelemetry) — ✅ shipped the core:

--- a/skills/causal-memory/SKILL.md
+++ b/skills/causal-memory/SKILL.md
@@ -51,8 +51,10 @@ This skill has two parts:
    is fine, an error means the server didn't come up.
 
 4. Optional shared/remote mode: `causal-memory http --port 9938` serves MCP
-   over Streamable HTTP at `/mcp` (multi-agent shared memory; set
-   `CAUSAL_MEMORY_ALLOWED_HOSTS` for non-localhost access).
+   over Streamable HTTP at `/mcp` (multi-agent shared memory; bind
+   `--host 0.0.0.0` for non-localhost access, and set
+   `CAUSAL_MEMORY_HTTP_AUTH_TOKEN` to protect the observability routes
+   `/metrics` and `/debug/*` when the port is reachable beyond loopback).
 
 ## 2. Usage (once the tools are available)
 


### PR DESCRIPTION
---

## 1. `84684ff` fix(hippocampus): CJK-aware simhash and jaccard via patterns::tokenize

simhash and text_jaccard_similarity had their own inline whitespace
tokenization while every retrieval path uses patterns::tokenize (ASCII
words minus stop words, CJK character bigrams). For unspaced text
(Chinese/Japanese) each sentence collapsed into one giant token:

- simhash hashed the whole sentence as a unit — a one-char edit changed
  the hash completely (hamming ~64/128), killing DG pattern separation
- detect_novelty's predicted-vs-actual jaccard was ~0 for any two
  different sentences → surprise ≈ 1.0 for everything → the novelty
  gate recorded every Chinese outcome (no-op gating), and Hybrid mode
  never reached its borderline band to consult the LLM
- the same flaw sat in prediction_gap_report (P5 semantic surprise)

Route both through patterns::tokenize, with a whole-text fallback in
simhash when tokenization yields nothing (all stop words/punctuation —
two such texts would otherwise both hash to 0 and trip the write-path
near-dup log). Note: text_jaccard_similarity keeps its own empty/empty
= 1.0 convention (patterns::jaccard defines 0.0); detect_novelty's
"nothing predicted" case depends on it.

sparse_code values persist under the new scheme; rows written before
0.9.3 keep old-scheme codes, so mixed-era hamming comparisons may miss
a near-dup log line (observability only — real dedup is exact-text;
documented at the read site, no migration).

Tests: simhash determinism + near-distance for Chinese, similar-vs-
different ordering (mirrors the English test), jaccard exact bigram
convention (4/5 = 0.8) + unrelated pair < 0.3, mixed-language, and the
detect_novelty regression (known Chinese outcome → surprise 0 / not
recorded; genuinely different outcome still gates).

Co-Authored-By: Claude <noreply@anthropic.com>

---

## 2. `6adfffc` feat(http): opt-in bearer auth for observability endpoints

/metrics, /debug/recall and /debug/recalls on the MCP HTTP server (and
/metrics on the AMC server) expose the recall corpus with no
authentication while the default bind is 0.0.0.0 — the README's own
"UNAUTHENTICATED — do not expose" warning. This adds opt-in bearer-token
auth so a deployed server can be locked down:

- CAUSAL_MEMORY_HTTP_AUTH_TOKEN (env or setconfig; empty/unset =
  disabled, byte-identical open behavior) requires
  `Authorization: Bearer <token>` on those routes. Scheme is
  case-insensitive; comparison is constant-time (safe-code XOR fold,
  black_boxed — workspace denies unsafe).
- Health probes (/health /healthz /readyz) stay open on purpose:
  kubelet liveness/readiness probes cannot attach bearer headers and
  these routes leak nothing beyond ok/DB-up status.
- /mcp is out of scope: MCP-client auth deserves its own design, and
  rmcp 2.2.0 already restricts it to loopback Host headers by default.
- AMC: only /metrics is gated — /add /search /health* are the challenge
  harness contract and auth is opt-in anyway.
- getconfig now masks *_TOKEN like *_KEY (otherwise it would print the
  secret in clear).
- Startup prints: token set → what's protected (+ weak-token warning
  under 16 chars); token unset + non-loopback bind → louder warning
  than before; unset + loopback → the old soft note.

The obs router is extracted into build_obs_router (was inline in
run_http_server) so it can be exercised end-to-end without an rmcp
service. Tests cover: no-token = fully open (back-compat), 401 without/
with wrong bearer (incl. WWW-Authenticate: Bearer per RFC 6750), 200
with the right bearer through the query-string debug route, probes open
when the token is set, AMC /metrics gated + contract routes unaffected,
constant_time_eq cases, and config allowlist/masking round-trip.

Co-Authored-By: Claude <noreply@anthropic.com>

---

## 3. `ac317be` docs: bearer auth usage + CJK fix notes; drop phantom ALLOWED_HOSTS env

README (en/zh): replace the "UNAUTHENTICATED — do not expose" warning
with the CAUSAL_MEMORY_HTTP_AUTH_TOKEN opt-in contract — what it
protects (/metrics, /debug/*), what stays open on purpose (health
probes), and that /mcp is out of scope (rmcp loopback Host allowlist).

CHANGELOG 0.9.3 Unreleased: ### Security for the auth feature, ###
Fixed for the CJK SimHash/Jaccard repair (including the sparse_code
scheme note for pre-0.9.3 rows). Roadmap: tick the observability-auth
half of the HTTP hardening item. SKILL.md: the http-mode note
referenced a nonexistent CAUSAL_MEMORY_ALLOWED_HOSTS env — replaced
with the real flags (--host, the auth token).