### PR TITLE
feat(rung3): Phase A — abduction substrate, decision forks, prediction ledger (schema v14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.9.3] - Unreleased
 
 ### Added
+- **Rung-3 Phase A: abduction substrate + natural experiments + prediction
+  ledger** (schema v14, [design](docs/design/counterfactual-rung3.md),
+  [prior-art survey](docs/research/computational-ai/rung3-prior-art.md)):
+  - `record_decision` gains an optional `context` param (MCP + Python):
+    the world state the decision was made in. Same task_tag + normalized
+    context ⇒ same fingerprint ⇒ comparable branch. Legacy rows/records
+    without context are unaffected.
+  - **Decision forks**: write-time detection links same-fingerprint edges
+    that took different decisions (natural experiments, capped pairs).
+    `counterfactual_query` renders a "🔀 Same-context branches" section
+    and a paired verdict that outranks the pooled distribution when
+    contrasting same-world pairs exist.
+  - **Prediction ledger**: every `counterfactual_query` verdict is logged
+    as a falsifiable prediction and auto-resolves when either option is
+    later recorded (first record wins; mixed/neutral actuals resolve
+    ambiguous, excluded from accuracy). New `prediction_report` (17th MCP
+    tool, Python binding mirrored): accuracy overall / per method / per
+    task_tag + pending list — the calibration dashboard.
+  - **Executable-replay routing (Phase-4 interface)**: closed-world
+    task_tags (build/test/config/bench) get a replay-plan note instead of
+    estimate-only advice; the trace/rerun engine stays future work.
+  - 17 new tests (fingerprint normalization, fork semantics, resolution
+    matrix, stats math, e2e log→resolve→report, closed-world routing);
+    workspace regression 430/430 green.
 - **Flip-path marking (recall provenance)** — every spreading-activation
   result now carries `hop` (0 = direct seed, N = lit in hop N) and `via`
   (the winning edge's relation + source). `search_causal` / `search_memory`

--- a/benches/longmemeval/main.rs
+++ b/benches/longmemeval/main.rs
@@ -789,6 +789,8 @@ fn expand_and_inject(
             discovered_at: 0,
             outcome_polarity: None,
             superseded_by: None,
+            context_fingerprint: None,
+            context_text: None,
         });
         synth_id -= 1;
     }

--- a/benches/memora/main.rs
+++ b/benches/memora/main.rs
@@ -771,8 +771,8 @@ fn semantic_search(
                         discovered_at: 0,
                         outcome_polarity: None,
                         superseded_by: None,
-            context_fingerprint: None,
-            context_text: None,
+                        context_fingerprint: None,
+                        context_text: None,
                     },
                     sim,
                 ));

--- a/benches/memora/main.rs
+++ b/benches/memora/main.rs
@@ -771,6 +771,8 @@ fn semantic_search(
                         discovered_at: 0,
                         outcome_polarity: None,
                         superseded_by: None,
+            context_fingerprint: None,
+            context_text: None,
                     },
                     sim,
                 ));

--- a/crates/causal-memory-cli/src/commands/misc.rs
+++ b/crates/causal-memory-cli/src/commands/misc.rs
@@ -785,6 +785,7 @@ mod obs_tests {
                 "rule",
                 1000,
                 Some("negative"),
+            None,
             )
             .unwrap();
         let store = std::sync::Arc::new(store);

--- a/crates/causal-memory-cli/src/lib.rs
+++ b/crates/causal-memory-cli/src/lib.rs
@@ -260,6 +260,7 @@ mod tests {
                 "rule",
                 1000,
                 Some("negative"),
+            None,
             )
             .unwrap();
         store
@@ -272,6 +273,7 @@ mod tests {
                 "user_feedback",
                 2000,
                 Some("positive"),
+            None,
             )
             .unwrap();
         // A meta edge over the two real decision chunks.
@@ -401,6 +403,7 @@ mod tests {
                 "rule",
                 1000,
                 Some("positive"),
+            None,
             )
             .unwrap();
         store

--- a/crates/causal-memory-cli/src/lib.rs
+++ b/crates/causal-memory-cli/src/lib.rs
@@ -260,7 +260,7 @@ mod tests {
                 "rule",
                 1000,
                 Some("negative"),
-            None,
+                None,
             )
             .unwrap();
         store
@@ -273,7 +273,7 @@ mod tests {
                 "user_feedback",
                 2000,
                 Some("positive"),
-            None,
+                None,
             )
             .unwrap();
         // A meta edge over the two real decision chunks.
@@ -403,7 +403,7 @@ mod tests {
                 "rule",
                 1000,
                 Some("positive"),
-            None,
+                None,
             )
             .unwrap();
         store
@@ -416,6 +416,7 @@ mod tests {
                 "rule",
                 1000,
                 Some("neutral"),
+                None,
             )
             .unwrap();
 

--- a/crates/causal-memory-cli/src/server/tools.rs
+++ b/crates/causal-memory-cli/src/server/tools.rs
@@ -472,7 +472,7 @@ impl CausalMemoryServer {
 
     #[tool(
         name = "counterfactual_query",
-        description = "Contrastive (empirical) counterfactual: compare the recorded outcomes of a decision vs an alternative in similar past situations. Call when choosing between two concrete options BEFORE acting. Reports recorded evidence only — this is NOT a Pearl Rung-3 SCM counterfactual."
+        description = "Contrastive (empirical) counterfactual: compare the recorded outcomes of a decision vs an alternative in similar past situations, with same-context branch (fork) evidence when available. Call when choosing between two concrete options BEFORE acting. Every verdict is logged as a falsifiable prediction that resolves automatically when either option is later recorded (see prediction_report). Reports recorded evidence — this is NOT a Pearl Rung-3 SCM counterfactual."
     )]
     fn counterfactual_query(&self, Parameters(params): Parameters<CounterfactualParams>) -> String {
         self.timed("counterfactual_query", || {
@@ -483,6 +483,14 @@ impl CausalMemoryServer {
                 params.limit,
             )
         })
+    }
+
+    #[tool(
+        name = "prediction_report",
+        description = "Prediction-ledger calibration dashboard: every counterfactual_query verdict is logged as a falsifiable prediction and auto-resolves when either option is later recorded. This reports accuracy overall, per method, and per task_tag, plus pending predictions. Call periodically to check whether the system's counterfactual advice is actually any good."
+    )]
+    fn prediction_report(&self) -> String {
+        self.timed("prediction_report", || self.memory.prediction_report())
     }
 
     #[tool(

--- a/crates/causal-memory-cli/src/server/tools.rs
+++ b/crates/causal-memory-cli/src/server/tools.rs
@@ -29,6 +29,14 @@ pub struct RecordDecisionParams {
         description = "Confidence source. Use: temporal, rule, llm_inferred, or user_feedback"
     )]
     pub confidence_source: Option<String>,
+    /// Short description of the situation the decision was made in
+    /// (environment, constraints, key parameters). Decisions recorded with
+    /// the same task_tag + context become comparable branches for
+    /// counterfactual queries.
+    #[schemars(
+        description = "Short description of the situation the decision was made in (environment, constraints, key parameters). Same task_tag + context ⇒ comparable branch (fork)"
+    )]
+    pub context: Option<String>,
 }
 
 /// Parameters for the `remember` tool — mem0-style auto-extraction.
@@ -275,6 +283,7 @@ impl CausalMemoryServer {
                 &params.relation,
                 &params.task_tag,
                 params.confidence_source.as_deref(),
+                params.context.as_deref(),
             )
         })
     }

--- a/crates/causal-memory-cli/tests/mcp_e2e.rs
+++ b/crates/causal-memory-cli/tests/mcp_e2e.rs
@@ -30,6 +30,7 @@ const EXPECTED_TOOLS: &[&str] = &[
     "causal_directory",
     "intervention_query",
     "counterfactual_query",
+    "prediction_report",
     "reconstruct_lesson",
 ];
 
@@ -114,7 +115,7 @@ async fn mcp_stdio_end_to_end() {
     let info = client.peer_info().expect("server must report its info");
     assert!(!info.server_info.name.is_empty());
 
-    // ── 2. tools/list: exactly the 16 documented tools.
+    // ── 2. tools/list: exactly the 17 documented tools.
     let tools = client.list_all_tools().await.unwrap();
     let names: HashSet<String> = tools.iter().map(|t| t.name.to_string()).collect();
     let expected: HashSet<String> = EXPECTED_TOOLS.iter().map(|s| s.to_string()).collect();

--- a/crates/causal-memory-py/src/lib.rs
+++ b/crates/causal-memory-py/src/lib.rs
@@ -63,7 +63,9 @@ impl PyCausalMemory {
     /// Call AFTER acting on a decision and observing the result.
     /// relation: caused / enabled / prevented / no_effect.
     /// confidence_source: temporal / rule / llm_inferred / user_feedback.
-    #[pyo3(signature = (decision, outcome, relation, task_tag, confidence_source=None))]
+    /// context: short situation description — same task_tag+context
+    /// becomes a comparable branch (fork) for counterfactual queries.
+    #[pyo3(signature = (decision, outcome, relation, task_tag, confidence_source=None, context=None))]
     fn record_decision(
         &self,
         py: Python<'_>,
@@ -72,10 +74,11 @@ impl PyCausalMemory {
         relation: &str,
         task_tag: &str,
         confidence_source: Option<&str>,
+        context: Option<&str>,
     ) -> String {
         py.allow_threads(|| {
             self.inner
-                .record_decision(decision, outcome, relation, task_tag, confidence_source)
+                .record_decision(decision, outcome, relation, task_tag, confidence_source, context)
         })
     }
 

--- a/crates/causal-memory-py/src/lib.rs
+++ b/crates/causal-memory-py/src/lib.rs
@@ -77,8 +77,14 @@ impl PyCausalMemory {
         context: Option<&str>,
     ) -> String {
         py.allow_threads(|| {
-            self.inner
-                .record_decision(decision, outcome, relation, task_tag, confidence_source, context)
+            self.inner.record_decision(
+                decision,
+                outcome,
+                relation,
+                task_tag,
+                confidence_source,
+                context,
+            )
         })
     }
 
@@ -260,6 +266,8 @@ impl PyCausalMemory {
 
     /// Contrastive (empirical) counterfactual: compare the recorded outcomes
     /// of a decision vs an alternative. NOT a Pearl Rung-3 SCM counterfactual.
+    /// Every verdict is logged as a falsifiable prediction (see
+    /// prediction_report); same-context branches (forks) render when present.
     #[pyo3(signature = (decision, alternative, task_tag=None, limit=None))]
     fn counterfactual_query(
         &self,
@@ -273,6 +281,13 @@ impl PyCausalMemory {
             self.inner
                 .counterfactual_query(decision, alternative, task_tag, limit)
         })
+    }
+
+    /// Prediction-ledger calibration dashboard: accuracy of past
+    /// counterfactual verdicts (overall / per method / per task_tag) plus
+    /// pending predictions that will resolve when either option is recorded.
+    fn prediction_report(&self, py: Python<'_>) -> String {
+        py.allow_threads(|| self.inner.prediction_report())
     }
 
     /// Reconstructive retrieval: Markov-blanket causal subgraph around a

--- a/crates/causal-memory-py/tests/test_smoke.py
+++ b/crates/causal-memory-py/tests/test_smoke.py
@@ -134,8 +134,11 @@ def test_reconstruct_lesson_no_llm(mem):
 
 def test_remember_no_llm(mem):
     out = mem.remember("user: I prefer tabs over spaces")
-    # Without an LLM endpoint, remember stores raw and says so.
-    assert "no LLM" in out or "Stored raw" in out
+    # Without an LLM endpoint the rule extractor still runs: preferences
+    # land as facts (the "no LLM → store raw" fallback predates the v0.9
+    # rule extractor).
+    assert "Extracted" in out or "no LLM" in out or "Stored raw" in out
+    assert "tabs" in out
 
 
 def test_causal_directory(mem):
@@ -158,26 +161,34 @@ def test_tilde_expansion(tmp_path, monkeypatch):
 
 def test_record_decision_context_and_prediction_ledger(mem):
     # v14: context param creates comparable branches (forks)…
+    # All four texts use disjoint vocabularies: BM25 matches decision AND
+    # outcome text, so any shared token pools both sides into both
+    # distributions (documented limitation — competitive separation is a
+    # Phase-3 refinement in the rung-3 design doc §4).
     mem.record_decision(
-        "used mysql for sessions",
-        "migration locks blocked deploys",
+        "picked mysql",
+        "migration deadlock",
         "caused",
         "database",
         context="rust agent, sqlite store, single node",
     )
     mem.record_decision(
-        "used postgres for sessions",
-        "clean cutover",
+        "adopted postgres",
+        "cutover passed",
         "caused",
         "database",
         context="RUST agent,   sqlite store, single node",  # same after normalization
     )
-    out = mem.counterfactual_query("used mysql for sessions", "used postgres for sessions")
+    out = mem.counterfactual_query("picked mysql", "adopted postgres")
     assert "Same-context branches" in out
     assert "Prediction #" in out
     # …and recording an option resolves the prediction automatically.
+    # ("passed" is a success token for the write-time polarity judge.)
     mem.record_decision(
-        "used postgres for sessions", "second migration also clean", "caused", "database"
+        "adopted postgres",
+        "second migration passed",
+        "caused",
+        "database",
     )
     report = mem.prediction_report()
     assert "1 resolved" in report

--- a/crates/causal-memory-py/tests/test_smoke.py
+++ b/crates/causal-memory-py/tests/test_smoke.py
@@ -154,3 +154,31 @@ def test_tilde_expansion(tmp_path, monkeypatch):
     mem = CausalMemory("~/cm-test/sub/causal.db")
     assert (tmp_path / "cm-test" / "sub" / "causal.db").exists()
     assert mem is not None
+
+
+def test_record_decision_context_and_prediction_ledger(mem):
+    # v14: context param creates comparable branches (forks)…
+    mem.record_decision(
+        "used mysql for sessions",
+        "migration locks blocked deploys",
+        "caused",
+        "database",
+        context="rust agent, sqlite store, single node",
+    )
+    mem.record_decision(
+        "used postgres for sessions",
+        "clean cutover",
+        "caused",
+        "database",
+        context="RUST agent,   sqlite store, single node",  # same after normalization
+    )
+    out = mem.counterfactual_query("used mysql for sessions", "used postgres for sessions")
+    assert "Same-context branches" in out
+    assert "Prediction #" in out
+    # …and recording an option resolves the prediction automatically.
+    mem.record_decision(
+        "used postgres for sessions", "second migration also clean", "caused", "database"
+    )
+    report = mem.prediction_report()
+    assert "1 resolved" in report
+    assert "accuracy 1/1 (100%)" in report

--- a/crates/causal-memory/src/memory/mod.rs
+++ b/crates/causal-memory/src/memory/mod.rs
@@ -28,6 +28,12 @@ const GRAPH_REBUILD_SECS: i64 = 30;
 
 /// Cosine floor for semantic seeding in intervention_query (recall-oriented).
 pub(crate) const INTERVENTION_MIN_SIMILARITY: f64 = 0.5;
+
+/// Phase-4 interface: task tags whose consequences live in deterministic
+/// environments (builds, tests, configs, benches). counterfactual_query
+/// routes these to an executable-replay plan — rerunning the alternative
+/// in a sandbox beats any estimate when the world is code.
+pub(crate) const CLOSED_WORLD_TAGS: [&str; 4] = ["build", "test", "config", "bench"];
 /// Cosine floor for the semantic contradiction scan on record (precision-
 /// oriented: only paraphrase-level duplicates of the same decision).
 pub(crate) const SEMANTIC_CONTRADICTION_MIN_SIMILARITY: f64 = 0.85;

--- a/crates/causal-memory/src/memory/ops.rs
+++ b/crates/causal-memory/src/memory/ops.rs
@@ -78,6 +78,9 @@ fn multi_pass_top_sessions() -> usize {
 
 impl Memory {
     /// `record_decision` — log a decision → outcome causal edge.
+    /// `context` (v14, optional): short description of the situation the
+    /// decision was made in — same task_tag+context becomes a comparable
+    /// branch (fork) for counterfactual queries.
     pub fn record_decision(
         &self,
         decision: &str,
@@ -85,6 +88,7 @@ impl Memory {
         relation: &str,
         task_tag: &str,
         confidence_source: Option<&str>,
+        context: Option<&str>,
     ) -> String {
         let confidence = match confidence_source {
             Some("temporal") => 0.4,
@@ -109,6 +113,7 @@ impl Memory {
             source,
             chrono::Utc::now().timestamp(),
             Some(&polarity),
+            context,
         ) {
             Ok((_dec_id, edge_id)) => {
                 // Phase C: patch the live graph so the new lesson is

--- a/crates/causal-memory/src/memory/ops.rs
+++ b/crates/causal-memory/src/memory/ops.rs
@@ -9,7 +9,10 @@ use super::format::{
     truncate_chars, TokenBudget,
 };
 use super::output::*;
-use super::{block_on, Memory, INTERVENTION_MIN_SIMILARITY, SEMANTIC_CONTRADICTION_MIN_SIMILARITY};
+use super::{
+    block_on, Memory, CLOSED_WORLD_TAGS, INTERVENTION_MIN_SIMILARITY,
+    SEMANTIC_CONTRADICTION_MIN_SIMILARITY,
+};
 use crate::store::{AgentFact, CausalEntry, ChainHop};
 
 /// One structured retrieval hit — the machine-readable form of
@@ -121,6 +124,20 @@ impl Memory {
                 if let Ok(Some(entry)) = self.store.get_edge(edge_id) {
                     self.patch_graph_new_edge(&entry);
                 }
+                // v14 prediction ledger: a recorded outcome for a decision
+                // text that a pending counterfactual predicted resolves it.
+                // Best-effort — resolution must never block recording.
+                let resolved = self
+                    .store
+                    .resolve_predictions_for_decision(decision, Some(&polarity))
+                    .unwrap_or(0);
+                let ledger_note = if resolved > 0 {
+                    format!(
+                        "\n📐 Resolved {resolved} pending prediction(s) about this decision — see prediction_report."
+                    )
+                } else {
+                    String::new()
+                };
                 // Opportunistically embed the new edge so semantic search
                 // finds it. Silent on any failure — embedding must never
                 // block recording; the `causal-memory embed` CLI backfills
@@ -142,7 +159,7 @@ impl Memory {
                     );
                 }
                 format!(
-                    "✅ Recorded: [{}] {} →({})→ {} (confidence: {:.2}, id: {})",
+                    "✅ Recorded: [{}] {} →({})→ {} (confidence: {:.2}, id: {}){ledger_note}",
                     task_tag,
                     truncate_chars(decision, 60),
                     relation,
@@ -1668,6 +1685,71 @@ impl Memory {
         self.counterfactual_inner(decision, alternative, task_tag, limit.unwrap_or(5))
     }
 
+    /// `prediction_report` (v14) — the prediction-ledger calibration
+    /// dashboard: resolved/correct/ambiguous/pending overall, per method and
+    /// per task_tag, plus the newest pending predictions. This is how the
+    /// system's counterfactual claims stay falsifiable instead of rhetorical.
+    pub fn prediction_report(&self) -> String {
+        let Ok(stats) = self.store.prediction_stats() else {
+            return "❌ Prediction report failed".to_string();
+        };
+        if stats.resolved == 0 && stats.pending == 0 {
+            return "📐 Prediction ledger is empty — counterfactual_query logs a \
+                    prediction every time it issues a verdict; predictions resolve \
+                    automatically when either option is later recorded."
+                .to_string();
+        }
+        let judged = stats.resolved - stats.ambiguous;
+        let mut out = format!(
+            "📐 Prediction ledger: {} resolved / {} pending\n",
+            stats.resolved, stats.pending
+        );
+        if stats.resolved > 0 {
+            out.push_str(&format!(
+                "   accuracy {}/{} ({:.0}%{}), {} ambiguous excluded\n",
+                stats.correct,
+                judged,
+                if judged > 0 {
+                    stats.correct as f64 / judged as f64 * 100.0
+                } else {
+                    0.0
+                },
+                if judged > 0 {
+                    ""
+                } else {
+                    ", no judged predictions yet"
+                },
+                stats.ambiguous
+            ));
+        }
+        let fmt_entry = |label: &str, e: &crate::store::PredictionStatsEntry| {
+            let denom = e.resolved - e.ambiguous;
+            format!(
+                "   {label}: {}/{} correct ({} ambiguous)\n",
+                e.correct, denom, e.ambiguous
+            )
+        };
+        for (method, e) in &stats.by_method {
+            out.push_str(&fmt_entry(&format!("method={method}"), e));
+        }
+        for (tag, e) in &stats.by_task_tag {
+            out.push_str(&fmt_entry(&format!("task_tag={tag}"), e));
+        }
+        if let Ok(pending) = self.store.pending_predictions(5) {
+            for p in pending {
+                out.push_str(&format!(
+                    "   pending #{} \"{}\" vs \"{}\" ({}, {})\n",
+                    p.id,
+                    truncate_chars(&p.option_a, 40),
+                    truncate_chars(&p.option_b, 40),
+                    p.task_tag,
+                    p.method
+                ));
+            }
+        }
+        out
+    }
+
     /// Counterfactual comparison with the embedder injected (None = keyword
     /// path, identical to unconfigured — keeps tests hermetic).
     pub fn counterfactual_inner(
@@ -1767,6 +1849,53 @@ impl Memory {
                 None => counterfactual_verdict(&dist_a, &dist_b),
             }
         ));
+        // v14 prediction ledger: every verdict becomes a falsifiable
+        // prediction, auto-resolved when either option is later recorded.
+        // The verdict string maps to prefer_a/prefer_b/no_difference for the
+        // ledger while the human-readable line stays as-is above.
+        let verdict_code = match &paired {
+            Some(p) if p.contains("favors A") => "prefer_a",
+            Some(p) if p.contains("favors B") => "prefer_b",
+            Some(_) => "no_difference", // tied contrasting pairs
+            None => match counterfactual_verdict(&dist_a, &dist_b) {
+                v if v.contains("favors A") => "prefer_a",
+                v if v.contains("favors B") => "prefer_b",
+                v if dist_a.total() > 0 && dist_b.total() > 0 => "no_difference",
+                _ => "",
+            },
+        };
+        if !verdict_code.is_empty() {
+            let strength = ((dist_a.score() - dist_b.score()).abs() / 4.0).clamp(0.1, 1.0);
+            if let Ok(id) = self.store.log_prediction(
+                decision,
+                alternative,
+                task_tag,
+                verdict_code,
+                "contrastive",
+                strength,
+                None,
+            ) {
+                out.push_str(&format!(
+                    "📐 Prediction #{id} logged — resolved automatically when either option is recorded.\n"
+                ));
+                // Phase-4 interface (executable replay routing): closed-world
+                // tags route to a replay plan instead of only an estimate.
+                // The engine (stepback-style trace + dirty-set rerun) is future
+                // work; this defines the routing + the ledger feedback path so
+                // method='executable' predictions can exist from day one.
+                if let Some(tag) = task_tag {
+                    if CLOSED_WORLD_TAGS.contains(&tag.to_lowercase().as_str()) {
+                        out.push_str(&format!(
+                            "🧪 Closed-world decision (task_tag={tag}): instead of estimating — replay it. \
+                             Apply the alternative in a sandbox, execute, then record the outcome with \
+                             record_decision(…, context=<same as the original edge>). The prediction \
+                             resolves automatically; over time prediction_report separates replayed facts \
+                             from estimates.\n"
+                        ));
+                    }
+                }
+            }
+        }
         out
     }
 

--- a/crates/causal-memory/src/memory/ops.rs
+++ b/crates/causal-memory/src/memory/ops.rs
@@ -1684,13 +1684,21 @@ impl Memory {
             let fb = self.side_evidence(alternative, task_tag, limit);
             tokio::join!(fa, fb)
         });
-        let (dist_a, reps_a, tag_a) = a;
-        let (dist_b, reps_b, tag_b) = b;
+        let (dist_a, reps_a, tag_a, ids_a) = a;
+        let (dist_b, reps_b, tag_b, ids_b) = b;
         let tag = if tag_a == "semantic" && tag_b == "semantic" {
             "[semantic]"
         } else {
             "[bm25]"
         };
+
+        // v14 fork section: same-context siblings of any retrieved edge are
+        // natural experiments — evidence about ONE world state rather than a
+        // cross-context aggregate. Best-effort: lookup failures just skip
+        // the section (output stays distribution-only).
+        let mut ids = ids_a.clone();
+        ids.extend_from_slice(&ids_b);
+        let forks = self.store.fork_siblings_for_edges(&ids).unwrap_or_default();
 
         let mut out = String::from(
             "⚠️ contrastive/empirical counterfactual over recorded alternatives — not a Pearl Rung-3 SCM counterfactual\n",
@@ -1713,9 +1721,51 @@ impl Memory {
                 out.push_str(&format!("   → {r}\n"));
             }
         }
+        if !forks.is_empty() {
+            out.push_str(&format!(
+                "\n🔀 Same-context branches (natural experiments, {} pair(s)):\n",
+                forks.len()
+            ));
+            for f in &forks {
+                // Which query side each endpoint matched (if any).
+                let side = |id: i64, decision_ids: &[i64]| {
+                    if decision_ids.contains(&id) {
+                        "A"
+                    } else {
+                        ""
+                    }
+                };
+                let sa = side(f.edge_id_a, &ids_a);
+                let sb = side(f.edge_id_b, &ids_b);
+                fn pol(p: &Option<String>) -> &str {
+                    p.as_deref().unwrap_or("?")
+                }
+                out.push_str(&format!(
+                    "   [{}] {}{} →({})→ \"{}\" [{}]  vs  {}{} →({})→ \"{}\" [{}]\n",
+                    truncate_chars(&f.fingerprint, 48),
+                    sa,
+                    truncate_chars(&f.a_decision, 40),
+                    f.a_relation,
+                    truncate_chars(&f.a_outcome, 40),
+                    pol(&f.a_polarity),
+                    sb,
+                    truncate_chars(&f.b_decision, 40),
+                    f.b_relation,
+                    truncate_chars(&f.b_outcome, 40),
+                    pol(&f.b_polarity),
+                ));
+            }
+        }
+        // Conclusion: paired (same-context) evidence outranks the pooled
+        // distributions when both exist — a fork pair is evidence about one
+        // world; distributions mix many.
+        let paired = paired_verdict(&forks, &ids_a, &ids_b);
         out.push_str(&format!(
             "\nConclusion: {}\n",
-            counterfactual_verdict(&dist_a, &dist_b)
+            match &paired {
+                Some(p) => format!("{p} (outranks the pooled distribution)"),
+                None => counterfactual_verdict(&dist_a, &dist_b),
+            }
         ));
         out
     }
@@ -1723,12 +1773,14 @@ impl Memory {
     /// One side of the counterfactual: retrieve similar past decision edges
     /// (semantic with BM25 fallback, same pattern as search_causal) and
     /// aggregate their outcome distribution + representative outcomes.
+    /// v14: also returns the retrieved edge ids — the fork-section lookup
+    /// needs them to find same-context siblings.
     async fn side_evidence(
         &self,
         query: &str,
         task_tag: Option<&str>,
         limit: usize,
-    ) -> (CfDist, Vec<String>, &'static str) {
+    ) -> (CfDist, Vec<String>, &'static str, Vec<i64>) {
         let semantic = crate::embed::embed_shared(query).await.and_then(|r| {
             let vec = r.ok()?;
             let hits = self
@@ -1773,7 +1825,8 @@ impl Memory {
                 )
             })
             .collect();
-        (dist, reps, path)
+        let edge_ids = entries.iter().map(|e| e.edge_id).collect();
+        (dist, reps, path, edge_ids)
     }
 
     /// `reconstruct_lesson` — reconstructive retrieval: Markov-blanket

--- a/crates/causal-memory/src/memory/ops.rs
+++ b/crates/causal-memory/src/memory/ops.rs
@@ -1809,16 +1809,17 @@ impl Memory {
                 forks.len()
             ));
             for f in &forks {
-                // Which query side each endpoint matched (if any).
-                let side = |id: i64, decision_ids: &[i64]| {
+                // Which query side each endpoint matched (if any): label
+                // only when the endpoint was retrieved BY that side.
+                let side = |id: i64, decision_ids: &[i64], label: &'static str| {
                     if decision_ids.contains(&id) {
-                        "A"
+                        label
                     } else {
                         ""
                     }
                 };
-                let sa = side(f.edge_id_a, &ids_a);
-                let sb = side(f.edge_id_b, &ids_b);
+                let sa = side(f.edge_id_a, &ids_a, "A");
+                let sb = side(f.edge_id_b, &ids_b, "B");
                 fn pol(p: &Option<String>) -> &str {
                     p.as_deref().unwrap_or("?")
                 }

--- a/crates/causal-memory/src/memory/output.rs
+++ b/crates/causal-memory/src/memory/output.rs
@@ -276,7 +276,7 @@ pub(crate) fn paired_verdict(
     }
     let (w, n) = if va > vb { ('A', va) } else { ('B', vb) };
     Some(format!(
-        "same-context branches favor {w} ({n}/{contrast} contrasting pair(s))"
+        "same-context evidence favors {w} ({n}/{contrast} contrasting pair(s))"
     ))
 }
 

--- a/crates/causal-memory/src/memory/output.rs
+++ b/crates/causal-memory/src/memory/output.rs
@@ -227,6 +227,59 @@ pub(crate) fn counterfactual_verdict(a: &CfDist, b: &CfDist) -> String {
     }
 }
 
+/// v14 paired (same-context) verdict over fork pairs. A pair votes for the
+/// query side whose branch ended positive while the other ended negative —
+/// a direct same-world-state contrast. `ids_a`/`ids_b` map pair endpoints
+/// to the query's A/B sides (an endpoint retrieved by neither side still
+/// renders in the display but casts no vote). None = no cross-side votes
+/// (caller falls back to the pooled-distribution verdict).
+pub(crate) fn paired_verdict(
+    forks: &[crate::store::ForkPair],
+    ids_a: &[i64],
+    ids_b: &[i64],
+) -> Option<String> {
+    let side_of = |id: i64| -> Option<char> {
+        if ids_a.contains(&id) {
+            Some('A')
+        } else if ids_b.contains(&id) {
+            Some('B')
+        } else {
+            None
+        }
+    };
+    let (mut va, mut vb, mut contrast) = (0usize, 0usize, 0usize);
+    for f in forks {
+        let (Some(sa), Some(sb)) = (side_of(f.edge_id_a), side_of(f.edge_id_b)) else {
+            continue;
+        };
+        if sa == sb {
+            continue; // both branches landed on the same query side
+        }
+        let (pa, pb) = (
+            f.a_polarity.as_deref().unwrap_or("?"),
+            f.b_polarity.as_deref().unwrap_or("?"),
+        );
+        let winner = match (pa, pb) {
+            ("positive", "negative") => Some(sa),
+            ("negative", "positive") => Some(sb),
+            _ => None,
+        };
+        contrast += 1;
+        match winner {
+            Some('A') => va += 1,
+            Some('B') => vb += 1,
+            _ => {}
+        }
+    }
+    if contrast == 0 || va == vb {
+        return None;
+    }
+    let (w, n) = if va > vb { ('A', va) } else { ('B', vb) };
+    Some(format!(
+        "same-context branches favor {w} ({n}/{contrast} contrasting pair(s))"
+    ))
+}
+
 /// Char-safe truncation to at most `n` chars, appending "…" when cut.
 pub(crate) fn edge_stub(e: &crate::store::CausalEntry) -> String {
     let pol = e.outcome_polarity.as_deref().unwrap_or("?");

--- a/crates/causal-memory/src/memory/tests.rs
+++ b/crates/causal-memory/src/memory/tests.rs
@@ -1010,7 +1010,7 @@ fn test_counterfactual_fork_section_and_paired_verdict() {
         "fork section must render: {out}"
     );
     assert!(
-        out.contains("same-context branches favor B"),
+        out.contains("same-context evidence favors B"),
         "paired verdict must favor B (channel won in the same world): {out}"
     );
     assert!(

--- a/crates/causal-memory/src/memory/tests.rs
+++ b/crates/causal-memory/src/memory/tests.rs
@@ -1062,3 +1062,118 @@ fn test_counterfactual_no_forks_output_unchanged() {
     );
     assert!(out.contains("recorded evidence favors B"), "{out}");
 }
+
+// ── v14 prediction ledger e2e ────────────────────────────────────
+
+#[test]
+fn test_prediction_ledger_e2e_log_resolve_report() {
+    let memory = Memory::open_in_memory().expect("memory");
+    // Seed evidence so a verdict fires (B wins: 2 negative vs 1 positive).
+    for (dec, out, _pol) in [
+        (
+            "used redis mutex for cache",
+            "deadlock under load",
+            "negative",
+        ),
+        ("used redis mutex for queue", "deadlock again", "negative"),
+        (
+            "switched to channel ownership",
+            "race fixed, all tests pass",
+            "positive",
+        ),
+    ] {
+        memory.record_decision(dec, out, "caused", "concurrency", None, None);
+    }
+    let out = memory.counterfactual_inner(
+        "used redis mutex for cache",
+        "switched to channel ownership",
+        Some("concurrency"),
+        5,
+    );
+    assert!(
+        out.contains("📐 Prediction #1 logged"),
+        "footer must report the ledger id: {out}"
+    );
+    // Reality: the agent actually takes the preferred option and wins.
+    let rec = memory.record_decision(
+        "switched to channel ownership",
+        "cutover succeeded, no deadlocks",
+        "caused",
+        "concurrency",
+        None,
+        None,
+    );
+    assert!(
+        rec.contains("Resolved 1 pending prediction"),
+        "record must report the auto-resolution: {rec}"
+    );
+    let report = memory.prediction_report();
+    assert!(
+        report.contains("1 resolved / 0 pending"),
+        "report header: {report}"
+    );
+    assert!(
+        report.contains("accuracy 1/1 (100%)"),
+        "preferred option won ⇒ correct: {report}"
+    );
+    assert!(
+        report.contains("method=contrastive: 1/1 correct"),
+        "per-method split: {report}"
+    );
+    assert!(
+        report.contains("task_tag=concurrency: 1/1 correct"),
+        "per-tag split: {report}"
+    );
+}
+
+#[test]
+fn test_prediction_report_empty_ledger() {
+    let memory = Memory::open_in_memory().expect("memory");
+    let report = memory.prediction_report();
+    assert!(
+        report.contains("Prediction ledger is empty"),
+        "empty ledger guidance: {report}"
+    );
+}
+
+#[test]
+fn test_counterfactual_closed_world_replay_routing() {
+    let memory = Memory::open_in_memory().expect("memory");
+    memory.record_decision(
+        "enabled lto in release profile",
+        "build time doubled, size -2%",
+        "caused",
+        "build",
+        None,
+        None,
+    );
+    memory.record_decision(
+        "kept default release profile",
+        "build time unchanged",
+        "caused",
+        "build",
+        None,
+        None,
+    );
+    let out = memory.counterfactual_inner(
+        "enabled lto in release profile",
+        "kept default release profile",
+        Some("build"),
+        5,
+    );
+    assert!(
+        out.contains("🧪 Closed-world decision"),
+        "closed-world tags must route to the replay plan: {out}"
+    );
+    // Open-world tag: no routing note.
+    let out2 = memory.counterfactual_inner(
+        "enabled lto in release profile",
+        "kept default release profile",
+        Some("release"),
+        5,
+    );
+    assert!(
+        !out2.contains("🧪"),
+        "open-world stays estimate-only: {out2}"
+    );
+}

--- a/crates/causal-memory/src/memory/tests.rs
+++ b/crates/causal-memory/src/memory/tests.rs
@@ -381,7 +381,7 @@ mod tests {
                 "rule",
                 1000,
                 Some("mixed"),
-            None,
+                None,
             )
             .unwrap();
         let edge = store.get_edge(1).unwrap().unwrap();
@@ -499,8 +499,7 @@ mod tests {
         let memory = Memory::open_in_memory().expect("memory");
         // 1 causal write + 5 fact writes ≥ GRAPH_REBUILD_WRITES (5): the
         // next hippocampus query must rebuild and see the fresh facts.
-        memory.record_decision("cfg", "zsh plugins load", "caused", "shell", None,
-            None,);
+        memory.record_decision("cfg", "zsh plugins load", "caused", "shell", None, None);
         for i in 0..5 {
             memory.record_fact(
                 &format!("pref_{i}"),
@@ -541,14 +540,16 @@ mod tests {
             "caused",
             "locking",
             None,
-            None,);
+            None,
+        );
         memory.record_decision(
             "ran backup migration",
             "backup completed",
             "caused",
             "backup",
             None,
-            None,);
+            None,
+        );
         memory.record_fact("tech_stack", "Redis 7.2", Some("user"), None, None);
         memory.record_fact("tech_stack", "Redis 8.0", Some("user"), None, Some(true));
 
@@ -578,7 +579,8 @@ mod tests {
             "caused",
             "rust",
             None,
-            None,);
+            None,
+        );
         memory.record_fact(
             "editor_preference",
             "user prefers TypeScript for module rewrites",
@@ -640,7 +642,8 @@ mod tests {
             "caused",
             "rust",
             None,
-            None,);
+            None,
+        );
         m1.record_fact(
             "editor_preference",
             "user prefers TypeScript for module rewrites",
@@ -707,7 +710,8 @@ fn multi_pass_sinks_bench_optimizations() {
             "caused",
             "garden",
             None,
-            None,);
+            None,
+        );
     }
     let out = memory.search_memory_multi_pass("how many plants did I buy", None, None, Some(10));
     // Flat-id store: no session expansion (documented), but the
@@ -737,7 +741,8 @@ fn search_memory_detail_levels_and_default_compat() {
         "caused",
         "concurrency",
         None,
-        None,);
+        None,
+    );
 
     let l2 = memory.search_memory("redis mutex", None, None, Some(10), None, None, None);
     let l0 = memory.search_memory("redis mutex", None, None, Some(10), Some("l0"), None, None);
@@ -785,7 +790,8 @@ fn search_memory_max_tokens_truncates() {
             "caused",
             "deploy",
             None,
-            None,);
+            None,
+        );
     }
     let full = memory.search_memory(
         "cache warmup deploy",
@@ -826,7 +832,8 @@ fn invalidate_pattern_soft_deletes_meta_edge() {
         "caused",
         "docker",
         None,
-        None,);
+        None,
+    );
     // Mine a pattern between the two chunks of that lesson.
     let (from_id, to_id) = {
         let store = memory.store();
@@ -893,14 +900,16 @@ fn search_explain_tags_and_default_invariance() {
         "caused",
         "release",
         None,
-        None,);
+        None,
+    );
     memory.record_decision(
         "deployed without env check",
         "crash loop in production",
         "caused",
         "release",
         None,
-        None,);
+        None,
+    );
 
     // Default == explicit explain=false, byte-identical, no ↳ markers.
     let default = memory.search_causal(None, Some("test suite release"), Some(5), None, None, None);
@@ -959,4 +968,97 @@ fn search_explain_tags_and_default_invariance() {
         .expect("audit row");
     assert!(row.result_count > 0);
     assert!(!row.results.as_array().unwrap().is_empty());
+}
+
+// ── v14 fork-aware counterfactual ────────────────────────────────
+
+#[test]
+fn test_counterfactual_fork_section_and_paired_verdict() {
+    let store = crate::store::CausalStore::open_in_memory().unwrap();
+    // One shared context, two branches — a natural experiment.
+    let ctx = Some("rust agent, cache redesign, v0.9");
+    for (dec, out, pol) in [
+        (
+            "used redis mutex for cache",
+            "deadlock under load",
+            "negative",
+        ),
+        (
+            "switched to channel ownership",
+            "race fixed, all tests pass",
+            "positive",
+        ),
+    ] {
+        store
+            .record_decision_full(
+                dec,
+                out,
+                "caused",
+                Some("concurrency"),
+                0.8,
+                "rule",
+                1000,
+                Some(pol),
+                ctx,
+            )
+            .unwrap();
+    }
+    let memory = Memory::new(store);
+    let out = memory.counterfactual_inner("redis mutex", "channel", None, 5);
+    assert!(
+        out.contains("🔀 Same-context branches (natural experiments, 1 pair(s))"),
+        "fork section must render: {out}"
+    );
+    assert!(
+        out.contains("same-context branches favor B"),
+        "paired verdict must favor B (channel won in the same world): {out}"
+    );
+    assert!(
+        out.contains("(outranks the pooled distribution)"),
+        "paired evidence must be flagged as outranking: {out}"
+    );
+}
+
+#[test]
+fn test_counterfactual_no_forks_output_unchanged() {
+    // Records WITHOUT context ⇒ no fork section, verdict stays
+    // distribution-based (byte-shape compatibility with pre-v14).
+    let store = crate::store::CausalStore::open_in_memory().unwrap();
+    for (i, (dec, out, pol)) in [
+        (
+            "used redis mutex for cache",
+            "deadlock under load",
+            "negative",
+        ),
+        ("used redis mutex for queue", "deadlock again", "negative"),
+        (
+            "switched to channel ownership",
+            "race fixed, all tests pass",
+            "positive",
+        ),
+    ]
+    .iter()
+    .enumerate()
+    {
+        store
+            .record_decision_full(
+                dec,
+                out,
+                "caused",
+                Some("concurrency"),
+                0.8,
+                "rule",
+                1000 + i as i64,
+                Some(pol),
+                None,
+            )
+            .unwrap();
+    }
+    let memory = Memory::new(store);
+    let out = memory.counterfactual_inner("redis mutex", "channel", None, 5);
+    assert!(
+        !out.contains("🔀"),
+        "no fork section without context: {out}"
+    );
+    assert!(out.contains("recorded evidence favors B"), "{out}");
 }

--- a/crates/causal-memory/src/memory/tests.rs
+++ b/crates/causal-memory/src/memory/tests.rs
@@ -32,6 +32,8 @@ mod tests {
             discovered_at: 0,
             outcome_polarity: None,
             superseded_by: None,
+            context_fingerprint: None,
+            context_text: None,
         };
         let (l0, t0) = format_entry_layered(&entry, 1, "l0");
         let (l2, t2) = format_entry_layered(&entry, 1, "l2");
@@ -323,6 +325,7 @@ mod tests {
                     "rule",
                     1000 + i as i64,
                     Some(pol),
+                    None,
                 )
                 .unwrap();
         }
@@ -378,6 +381,7 @@ mod tests {
                 "rule",
                 1000,
                 Some("mixed"),
+            None,
             )
             .unwrap();
         let edge = store.get_edge(1).unwrap().unwrap();
@@ -495,7 +499,8 @@ mod tests {
         let memory = Memory::open_in_memory().expect("memory");
         // 1 causal write + 5 fact writes ≥ GRAPH_REBUILD_WRITES (5): the
         // next hippocampus query must rebuild and see the fresh facts.
-        memory.record_decision("cfg", "zsh plugins load", "caused", "shell", None);
+        memory.record_decision("cfg", "zsh plugins load", "caused", "shell", None,
+            None,);
         for i in 0..5 {
             memory.record_fact(
                 &format!("pref_{i}"),
@@ -536,14 +541,14 @@ mod tests {
             "caused",
             "locking",
             None,
-        );
+            None,);
         memory.record_decision(
             "ran backup migration",
             "backup completed",
             "caused",
             "backup",
             None,
-        );
+            None,);
         memory.record_fact("tech_stack", "Redis 7.2", Some("user"), None, None);
         memory.record_fact("tech_stack", "Redis 8.0", Some("user"), None, Some(true));
 
@@ -573,7 +578,7 @@ mod tests {
             "caused",
             "rust",
             None,
-        );
+            None,);
         memory.record_fact(
             "editor_preference",
             "user prefers TypeScript for module rewrites",
@@ -635,7 +640,7 @@ mod tests {
             "caused",
             "rust",
             None,
-        );
+            None,);
         m1.record_fact(
             "editor_preference",
             "user prefers TypeScript for module rewrites",
@@ -702,7 +707,7 @@ fn multi_pass_sinks_bench_optimizations() {
             "caused",
             "garden",
             None,
-        );
+            None,);
     }
     let out = memory.search_memory_multi_pass("how many plants did I buy", None, None, Some(10));
     // Flat-id store: no session expansion (documented), but the
@@ -732,7 +737,7 @@ fn search_memory_detail_levels_and_default_compat() {
         "caused",
         "concurrency",
         None,
-    );
+        None,);
 
     let l2 = memory.search_memory("redis mutex", None, None, Some(10), None, None, None);
     let l0 = memory.search_memory("redis mutex", None, None, Some(10), Some("l0"), None, None);
@@ -780,7 +785,7 @@ fn search_memory_max_tokens_truncates() {
             "caused",
             "deploy",
             None,
-        );
+            None,);
     }
     let full = memory.search_memory(
         "cache warmup deploy",
@@ -821,7 +826,7 @@ fn invalidate_pattern_soft_deletes_meta_edge() {
         "caused",
         "docker",
         None,
-    );
+        None,);
     // Mine a pattern between the two chunks of that lesson.
     let (from_id, to_id) = {
         let store = memory.store();
@@ -888,14 +893,14 @@ fn search_explain_tags_and_default_invariance() {
         "caused",
         "release",
         None,
-    );
+        None,);
     memory.record_decision(
         "deployed without env check",
         "crash loop in production",
         "caused",
         "release",
         None,
-    );
+        None,);
 
     // Default == explicit explain=false, byte-identical, no ↳ markers.
     let default = memory.search_causal(None, Some("test suite release"), Some(5), None, None, None);

--- a/crates/causal-memory/src/migrate.rs
+++ b/crates/causal-memory/src/migrate.rs
@@ -31,7 +31,7 @@ use rusqlite::{params, Connection};
 use crate::store::CAUSAL_SCHEMA_SQL;
 
 /// Current schema version. Bump when adding a new migration step.
-pub const SCHEMA_VERSION: u32 = 13;
+pub const SCHEMA_VERSION: u32 = 14;
 
 /// Bring `conn` up to `SCHEMA_VERSION`. Runs in a single transaction:
 /// any failure rolls everything back.
@@ -82,6 +82,9 @@ pub fn migrate(conn: &Connection) -> Result<()> {
     }
     if version < 13 {
         migrate_to_v13(&tx)?;
+    }
+    if version < 14 {
+        migrate_to_v14(&tx)?;
     }
 
     // Creates any missing tables/indexes at v3 (no-op for existing ones).
@@ -968,5 +971,41 @@ fn migrate_to_v12(conn: &Connection) -> Result<()> {
 /// step covers existing DBs (idempotent).
 fn migrate_to_v13(conn: &Connection) -> Result<()> {
     conn.execute_batch(crate::store::RECALL_AUDIT_DDL)?;
+    Ok(())
+}
+
+/// v13 → v14: Rung-3 Phase A (counterfactual rung-3 design, 2026-09).
+///
+/// - `causal_edges.context_fingerprint` + `context_text`: the abduction
+///   substrate — records the world state a decision was made in so
+///   same-context decisions become comparable branches. NULL on all
+///   legacy rows (excluded from fork logic by construction).
+/// - `decision_forks` + `pending_predictions`: created by
+///   RUNG3_PHASE_A_TABLES_DDL (idempotent; fresh DBs also get them from
+///   CAUSAL_SCHEMA_SQL).
+/// - The fingerprint index is a partial index (WHERE … IS NOT NULL) so
+///   legacy-heavy DBs don't index a sea of NULLs.
+fn migrate_to_v14(conn: &Connection) -> Result<()> {
+    if table_exists(conn, "causal_edges")? {
+        let cols = table_columns(conn, "causal_edges")?;
+        if !cols.contains("context_fingerprint") {
+            conn.execute_batch(
+                "ALTER TABLE causal_edges ADD COLUMN context_fingerprint TEXT",
+            )?;
+        }
+        if !cols.contains("context_text") {
+            conn.execute_batch("ALTER TABLE causal_edges ADD COLUMN context_text TEXT")?;
+        }
+    }
+    conn.execute_batch(crate::store::RUNG3_PHASE_A_TABLES_DDL)?;
+    // The index needs causal_edges to exist; partial fixture DBs (e.g. the
+    // v6→v7 test) may not have it — CAUSAL_SCHEMA_SQL creates both the table
+    // and the index right after the per-version steps.
+    if table_exists(conn, "causal_edges")? {
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_causal_fingerprint
+             ON causal_edges(context_fingerprint) WHERE context_fingerprint IS NOT NULL;",
+        )?;
+    }
     Ok(())
 }

--- a/crates/causal-memory/src/migrate.rs
+++ b/crates/causal-memory/src/migrate.rs
@@ -989,9 +989,7 @@ fn migrate_to_v14(conn: &Connection) -> Result<()> {
     if table_exists(conn, "causal_edges")? {
         let cols = table_columns(conn, "causal_edges")?;
         if !cols.contains("context_fingerprint") {
-            conn.execute_batch(
-                "ALTER TABLE causal_edges ADD COLUMN context_fingerprint TEXT",
-            )?;
+            conn.execute_batch("ALTER TABLE causal_edges ADD COLUMN context_fingerprint TEXT")?;
         }
         if !cols.contains("context_text") {
             conn.execute_batch("ALTER TABLE causal_edges ADD COLUMN context_text TEXT")?;

--- a/crates/causal-memory/src/retrieval.rs
+++ b/crates/causal-memory/src/retrieval.rs
@@ -760,6 +760,8 @@ mod tests {
             discovered_at: 0,
             outcome_polarity: None,
             superseded_by: None,
+            context_fingerprint: None,
+            context_text: None,
         };
         // Rank-ordered pool: 5 episodes above 5 originals (the §4 shape —
         // BM25 length normalization floats the summaries).

--- a/crates/causal-memory/src/store/mod.rs
+++ b/crates/causal-memory/src/store/mod.rs
@@ -80,6 +80,14 @@ CREATE TABLE IF NOT EXISTS causal_edges (
     -- supersession marks instead of deletes; `restore_edge` clears both this
     -- and valid_to when later evidence proves the old memory right.
     superseded_by INTEGER,
+    -- v14 (Rung-3 Phase A): the abduction substrate. `context_fingerprint`
+    -- = task_tag + US + normalize(context) — same fingerprint ⇒ the two
+    -- decisions were made in (recorded as) the same world state, making
+    -- them comparable branches (decision_forks). NULL = no context given
+    -- (legacy rows; excluded from fork logic). `context_text` keeps the
+    -- raw description for display/audit.
+    context_fingerprint TEXT,
+    context_text TEXT,
     FOREIGN KEY (from_id) REFERENCES chunks(id),
     FOREIGN KEY (to_id) REFERENCES chunks(id)
 );
@@ -88,6 +96,8 @@ CREATE INDEX IF NOT EXISTS idx_causal_to ON causal_edges(to_id);
 CREATE INDEX IF NOT EXISTS idx_causal_task ON causal_edges(task_tag);
 CREATE INDEX IF NOT EXISTS idx_causal_event_time ON causal_edges(event_time);
 CREATE INDEX IF NOT EXISTS idx_causal_valid ON causal_edges(valid_to);
+CREATE INDEX IF NOT EXISTS idx_causal_fingerprint
+    ON causal_edges(context_fingerprint) WHERE context_fingerprint IS NOT NULL;
 
 -- Meta causal edges: decision → decision (cross-task patterns)
 -- Stratification fields (v5): the miner's replication test fills them;
@@ -197,6 +207,50 @@ CREATE TABLE IF NOT EXISTS recall_audit (
     result_count INTEGER NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_recall_audit_created ON recall_audit(created_at);
+
+-- Decision forks (schema v14, Rung-3 Phase A): pairs of valid causal edges
+-- that share a context_fingerprint but chose DIFFERENT decisions — natural
+-- experiments. Written opportunistically by record_decision_full; the pair
+-- is stored id-ordered and UNIQUE-deduped. Counterfactual_query reads these
+-- to compare same-context branches instead of pooling cross-context
+-- distributions. Keep in sync with RUNG3_PHASE_A_TABLES_DDL below.
+CREATE TABLE IF NOT EXISTS decision_forks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    edge_id_a INTEGER NOT NULL,
+    edge_id_b INTEGER NOT NULL,
+    fingerprint TEXT NOT NULL,
+    discovered_at INTEGER NOT NULL,
+    UNIQUE(edge_id_a, edge_id_b),
+    FOREIGN KEY (edge_id_a) REFERENCES causal_edges(id),
+    FOREIGN KEY (edge_id_b) REFERENCES causal_edges(id)
+);
+CREATE INDEX IF NOT EXISTS idx_forks_a ON decision_forks(edge_id_a);
+CREATE INDEX IF NOT EXISTS idx_forks_b ON decision_forks(edge_id_b);
+
+-- Prediction ledger (schema v14, Rung-3 Phase A): every counterfactual_query
+-- verdict becomes a falsifiable prediction. Resolved automatically when
+-- either option is later recorded via record_decision (exact-text match,
+-- consistent with chunk reuse); `correct` is NULL while pending or when the
+-- actual outcome polarity is ambiguous (mixed/neutral). Powers the
+-- prediction_report calibration dashboard. Keep in sync with
+-- RUNG3_PHASE_A_TABLES_DDL below.
+CREATE TABLE IF NOT EXISTS pending_predictions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    created_at INTEGER NOT NULL,
+    option_a TEXT NOT NULL,
+    option_b TEXT NOT NULL,
+    task_tag TEXT,
+    verdict TEXT NOT NULL CHECK(verdict IN ('prefer_a','prefer_b','no_difference')),
+    method TEXT NOT NULL,
+    confidence REAL NOT NULL,
+    evidence TEXT,
+    resolved_at INTEGER,
+    resolved_option TEXT CHECK(resolved_option IS NULL OR resolved_option IN ('a','b')),
+    actual_polarity TEXT,
+    correct INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_predictions_pending
+    ON pending_predictions(resolved_at) WHERE resolved_at IS NULL;
 "#;
 
 /// Recall audit table (schema v13, observability): one best-effort row per
@@ -220,6 +274,63 @@ CREATE TABLE IF NOT EXISTS recall_audit (
 );
 CREATE INDEX IF NOT EXISTS idx_recall_audit_created ON recall_audit(created_at);
 "#;
+
+/// Rung-3 Phase A tables (schema v14): decision forks + the prediction
+/// ledger. Single source of truth for their DDL; the v14 migration replays
+/// this for existing DBs (idempotent IF NOT EXISTS). The context columns on
+/// `causal_edges` cannot live here (ALTER ADD COLUMN), so migrate_to_v14
+/// adds them inline.
+pub const RUNG3_PHASE_A_TABLES_DDL: &str = r#"
+CREATE TABLE IF NOT EXISTS decision_forks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    edge_id_a INTEGER NOT NULL,
+    edge_id_b INTEGER NOT NULL,
+    fingerprint TEXT NOT NULL,
+    discovered_at INTEGER NOT NULL,
+    UNIQUE(edge_id_a, edge_id_b),
+    FOREIGN KEY (edge_id_a) REFERENCES causal_edges(id),
+    FOREIGN KEY (edge_id_b) REFERENCES causal_edges(id)
+);
+CREATE INDEX IF NOT EXISTS idx_forks_a ON decision_forks(edge_id_a);
+CREATE INDEX IF NOT EXISTS idx_forks_b ON decision_forks(edge_id_b);
+CREATE TABLE IF NOT EXISTS pending_predictions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    created_at INTEGER NOT NULL,
+    option_a TEXT NOT NULL,
+    option_b TEXT NOT NULL,
+    task_tag TEXT,
+    verdict TEXT NOT NULL CHECK(verdict IN ('prefer_a','prefer_b','no_difference')),
+    method TEXT NOT NULL,
+    confidence REAL NOT NULL,
+    evidence TEXT,
+    resolved_at INTEGER,
+    resolved_option TEXT CHECK(resolved_option IS NULL OR resolved_option IN ('a','b')),
+    actual_polarity TEXT,
+    correct INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_predictions_pending
+    ON pending_predictions(resolved_at) WHERE resolved_at IS NULL;
+"#;
+
+/// Normalize a context description into the fingerprint contribution:
+/// lowercase, collapse runs of whitespace. Order-preserving on purpose —
+/// context is a short structured description ("rust, sqlite, wal off"),
+/// not free prose where word order is arbitrary.
+pub(crate) fn normalize_context_text(context: &str) -> String {
+    context.to_lowercase().split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Build the v14 context fingerprint: `task_tag + US + normalized context`
+/// (both sides lowercased/whitespace-collapsed). Same fingerprint ⇒
+/// recorded as the same world state (the abduction anchor for forks and
+/// counterfactuals).
+pub(crate) fn context_fingerprint(task_tag: Option<&str>, context: &str) -> String {
+    format!(
+        "{}\u{1f}{}",
+        normalize_context_text(task_tag.unwrap_or("")),
+        normalize_context_text(context)
+    )
+}
 
 /// Thread-safe causal store backed by SQLite.
 ///

--- a/crates/causal-memory/src/store/mod.rs
+++ b/crates/causal-memory/src/store/mod.rs
@@ -317,7 +317,11 @@ CREATE INDEX IF NOT EXISTS idx_predictions_pending
 /// context is a short structured description ("rust, sqlite, wal off"),
 /// not free prose where word order is arbitrary.
 pub(crate) fn normalize_context_text(context: &str) -> String {
-    context.to_lowercase().split_whitespace().collect::<Vec<_>>().join(" ")
+    context
+        .to_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Build the v14 context fingerprint: `task_tag + US + normalized context`

--- a/crates/causal-memory/src/store/retrieve/semantic.rs
+++ b/crates/causal-memory/src/store/retrieve/semantic.rs
@@ -30,7 +30,7 @@ impl CausalStore {
         let mut stmt = conn.prepare(&sql)?;
         let bind_refs: Vec<&dyn rusqlite::ToSql> = bind.iter().map(|b| b.as_ref()).collect();
         let rows = stmt.query_map(bind_refs.as_slice(), |row| {
-            Ok((entry_from_row(row)?, row.get::<_, Vec<u8>>(16)?))
+            Ok((entry_from_row(row)?, row.get::<_, Vec<u8>>(18)?))
         })?;
 
         let mut scored: Vec<(crate::store::CausalEntry, f64)> = Vec::new();
@@ -89,7 +89,7 @@ impl CausalStore {
         let mut stmt = conn.prepare(&sql)?;
         let bind_refs: Vec<&dyn rusqlite::ToSql> = bind.iter().map(|b| b.as_ref()).collect();
         let rows = stmt.query_map(rusqlite::params_from_iter(bind_refs), |row| {
-            Ok((entry_from_row(row)?, row.get::<_, Vec<u8>>(16)?))
+            Ok((entry_from_row(row)?, row.get::<_, Vec<u8>>(18)?))
         })?;
         let mut scored: Vec<(crate::store::CausalEntry, f64)> = Vec::new();
         for row in rows {

--- a/crates/causal-memory/src/store/tests.rs
+++ b/crates/causal-memory/src/store/tests.rs
@@ -3406,3 +3406,133 @@ fn test_fork_lookup_skips_invalidated_edges() {
         "a pair whose edge was invalidated must not surface"
     );
 }
+
+// ─── v14 prediction ledger (Rung-3 Phase A: falsifiability) ─────────
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test invariant: panicking on failure is desired"
+)]
+fn test_prediction_resolution_matrix() {
+    // (verdict, which option gets recorded, actual polarity, expected correct)
+    let matrix = [
+        ("prefer_a", "a", "positive", Some(1)),
+        ("prefer_a", "a", "negative", Some(0)),
+        ("prefer_a", "b", "positive", Some(0)), // rejected option won
+        ("prefer_a", "b", "negative", Some(1)), // rival failed as predicted
+        ("prefer_a", "a", "mixed", None),       // ambiguous actual
+        ("no_difference", "a", "positive", None),
+    ];
+    for (i, (verdict, took, pol, expected)) in matrix.iter().enumerate() {
+        let store = CausalStore::open_in_memory().unwrap();
+        let id = store
+            .log_prediction(
+                "option A text",
+                "option B text",
+                Some("t"),
+                verdict,
+                "contrastive",
+                0.5,
+                None,
+            )
+            .unwrap();
+        let recorded = if *took == "a" {
+            "option A text"
+        } else {
+            "option B text"
+        };
+        assert_eq!(
+            store
+                .resolve_predictions_for_decision(recorded, Some(pol))
+                .unwrap(),
+            1,
+            "case {i}: one prediction must resolve"
+        );
+        let correct: Option<i64> = store
+            .with_conn(|conn| {
+                Ok(conn.query_row(
+                    "SELECT correct FROM pending_predictions WHERE id = ?1",
+                    rusqlite::params![id],
+                    |r| r.get(0),
+                )?)
+            })
+            .unwrap();
+        assert_eq!(
+            correct, *expected,
+            "case {i} ({verdict}, took {took}, {pol})"
+        );
+        // Single resolution: a second matching record must not re-resolve.
+        store
+            .record_decision_full(
+                recorded,
+                "later different outcome",
+                "caused",
+                Some("t"),
+                0.8,
+                "rule",
+                2000,
+                Some("negative"),
+                None,
+            )
+            .unwrap();
+        assert_eq!(
+            store
+                .resolve_predictions_for_decision(recorded, Some("positive"))
+                .unwrap(),
+            0,
+            "case {i}: already resolved"
+        );
+    }
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test invariant: panicking on failure is desired"
+)]
+fn test_prediction_stats_and_pending_list() {
+    let store = CausalStore::open_in_memory().unwrap();
+    // 2 correct, 1 wrong, 1 ambiguous (resolved); 2 pending.
+    store
+        .log_prediction("a1", "b1", Some("x"), "prefer_a", "contrastive", 0.5, None)
+        .unwrap();
+    store
+        .log_prediction("a2", "b2", Some("x"), "prefer_a", "contrastive", 0.5, None)
+        .unwrap();
+    store
+        .log_prediction("a3", "b3", Some("y"), "prefer_b", "contrastive", 0.5, None)
+        .unwrap();
+    store
+        .log_prediction("a4", "b4", Some("y"), "prefer_a", "contrastive", 0.5, None)
+        .unwrap();
+    store
+        .log_prediction("a5", "b5", Some("y"), "prefer_a", "contrastive", 0.5, None)
+        .unwrap();
+    store
+        .log_prediction("a6", "b6", None, "prefer_b", "contrastive", 0.5, None)
+        .unwrap();
+    store
+        .resolve_predictions_for_decision("a1", Some("positive"))
+        .unwrap(); // correct
+    store
+        .resolve_predictions_for_decision("a2", Some("positive"))
+        .unwrap(); // correct
+    store
+        .resolve_predictions_for_decision("a3", Some("positive"))
+        .unwrap(); // preferred B, took A positive → wrong
+    store
+        .resolve_predictions_for_decision("a4", Some("mixed"))
+        .unwrap(); // ambiguous
+    let stats = store.prediction_stats().unwrap();
+    assert_eq!(stats.resolved, 4);
+    assert_eq!(stats.correct, 2);
+    assert_eq!(stats.ambiguous, 1);
+    assert_eq!(stats.pending, 2);
+    assert_eq!(stats.by_method["contrastive"].resolved, 4);
+    assert_eq!(stats.by_task_tag["x"].correct, 2);
+    assert_eq!(stats.by_task_tag["y"].correct, 0);
+    let pending = store.pending_predictions(10).unwrap();
+    assert_eq!(pending.len(), 2);
+    assert_eq!(pending[0].option_a, "a6", "newest first");
+}

--- a/crates/causal-memory/src/store/tests.rs
+++ b/crates/causal-memory/src/store/tests.rs
@@ -809,6 +809,7 @@ fn test_record_with_polarity_and_cte_propagation() {
             "rule",
             1000,
             Some("mixed"),
+        None,
         )
         .unwrap();
     store
@@ -833,6 +834,7 @@ fn test_contradiction_stored_polarity() {
                 "rule",
                 1000,
                 polarity,
+            None,
             )
             .unwrap();
     };
@@ -878,6 +880,7 @@ fn test_semantic_contradiction_stored_polarity() {
             "rule",
             1000,
             Some("mixed"),
+        None,
         )
         .unwrap();
     // Edge 2: stored 'negative' with a neutral-looking text — stored wins,
@@ -892,6 +895,7 @@ fn test_semantic_contradiction_stored_polarity() {
             "rule",
             1001,
             Some("negative"),
+        None,
         )
         .unwrap();
     store.put_embedding(1, "test", &[1.0, 0.0]).unwrap();
@@ -3162,4 +3166,119 @@ fn test_recall_audit_roundtrip_newest_first() {
     // JSON fields decode back.
     assert_eq!(entries[0].results[0]["explain"], "[seed]");
     assert_eq!(entries[1].seeds[0]["source"], "bm25");
+}
+
+// ─── v14 context fingerprint (Rung-3 Phase A: abduction substrate) ───
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test invariant: panicking on failure is desired"
+)]
+fn test_context_fingerprint_normalization() {
+    use super::context_fingerprint;
+    // Case + whitespace runs collapse; order preserved.
+    assert_eq!(
+        context_fingerprint(Some("Rust"), "SQLite,  WAL   OFF"),
+        context_fingerprint(Some("rust"), "sqlite, wal off")
+    );
+    // Different task_tag ⇒ different world state.
+    assert_ne!(
+        context_fingerprint(Some("a"), "same ctx"),
+        context_fingerprint(Some("b"), "same ctx")
+    );
+    // Separator keeps tag and context from colliding.
+    let fp = context_fingerprint(None, "x");
+    assert!(fp.starts_with('\u{1f}'), "no-tag fingerprint: {fp:?}");
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test invariant: panicking on failure is desired"
+)]
+fn test_record_with_context_persists_fingerprint() {
+    let store = CausalStore::open_in_memory().unwrap();
+    store
+        .record_decision_full(
+            "used mysql for sessions",
+            "migration locks blocked deploys",
+            "caused",
+            Some("database"),
+            0.8,
+            "rule",
+            1000,
+            Some("negative"),
+            Some("rust agent, sqlite store, single node"),
+        )
+        .unwrap();
+    store
+        .record_decision_at(
+            "used postgres for sessions",
+            "clean cutover",
+            "caused",
+            Some("database"),
+            0.9,
+            "rule",
+            2000,
+        )
+        .unwrap();
+    let edges = store.all_valid_edges().unwrap();
+    let with_ctx = edges
+        .iter()
+        .find(|e| e.decision_text.contains("mysql"))
+        .unwrap();
+    let without_ctx = edges
+        .iter()
+        .find(|e| e.decision_text.contains("postgres"))
+        .unwrap();
+    assert_eq!(
+        with_ctx.context_fingerprint.as_deref(),
+        Some("database\u{1f}rust agent, sqlite store, single node"),
+        "fingerprint = task_tag US normalized context"
+    );
+    assert_eq!(
+        with_ctx.context_text.as_deref(),
+        Some("rust agent, sqlite store, single node")
+    );
+    assert!(
+        without_ctx.context_fingerprint.is_none() && without_ctx.context_text.is_none(),
+        "no context given ⇒ NULL columns (legacy behavior)"
+    );
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test invariant: panicking on failure is desired"
+)]
+fn test_migration_v14_adds_columns_and_tables_idempotently() {
+    // Build a pre-v14 DB by hand: causal_edges WITHOUT the context columns,
+    // user_version=13 — then run migrate and check the upgrade.
+    let store = CausalStore::open_in_memory().unwrap();
+    store
+        .with_conn(|conn| {
+            // Simulate the legacy shape: drop the new columns is impossible
+            // (SQLite), so instead verify the fresh-DB path has them and the
+            // tables exist, then re-run migrate() — must be a no-op success.
+            let cols: Vec<String> = {
+                let mut stmt = conn.prepare("PRAGMA table_info(causal_edges)")?;
+                let rows = stmt.query_map([], |r| r.get::<_, String>(1))?;
+                rows.collect::<rusqlite::Result<Vec<_>>>()?
+            };
+            assert!(cols.contains(&"context_fingerprint".to_string()));
+            assert!(cols.contains(&"context_text".to_string()));
+            for table in ["decision_forks", "pending_predictions"] {
+                let n: i64 = conn.query_row(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?1",
+                    rusqlite::params![table],
+                    |r| r.get(0),
+                )?;
+                assert_eq!(n, 1, "{table} must exist at v14");
+            }
+            // Idempotent: migrating an already-current DB must succeed.
+            crate::migrate::migrate(conn)?;
+            Ok(())
+        })
+        .unwrap();
 }

--- a/crates/causal-memory/src/store/tests.rs
+++ b/crates/causal-memory/src/store/tests.rs
@@ -809,7 +809,7 @@ fn test_record_with_polarity_and_cte_propagation() {
             "rule",
             1000,
             Some("mixed"),
-        None,
+            None,
         )
         .unwrap();
     store
@@ -834,7 +834,7 @@ fn test_contradiction_stored_polarity() {
                 "rule",
                 1000,
                 polarity,
-            None,
+                None,
             )
             .unwrap();
     };
@@ -880,7 +880,7 @@ fn test_semantic_contradiction_stored_polarity() {
             "rule",
             1000,
             Some("mixed"),
-        None,
+            None,
         )
         .unwrap();
     // Edge 2: stored 'negative' with a neutral-looking text — stored wins,
@@ -895,7 +895,7 @@ fn test_semantic_contradiction_stored_polarity() {
             "rule",
             1001,
             Some("negative"),
-        None,
+            None,
         )
         .unwrap();
     store.put_embedding(1, "test", &[1.0, 0.0]).unwrap();
@@ -3281,4 +3281,128 @@ fn test_migration_v14_adds_columns_and_tables_idempotently() {
             Ok(())
         })
         .unwrap();
+}
+
+// ─── v14 decision forks (Rung-3 Phase A: natural experiments) ────────
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test invariant: panicking on failure is desired"
+)]
+fn test_fork_pairs_created_for_same_context_different_decisions() {
+    let store = CausalStore::open_in_memory().unwrap();
+    let ctx = Some("rust agent, sqlite, single node");
+    for dec in ["used mysql", "used postgres", "used sqlite"] {
+        store
+            .record_decision_full(
+                dec,
+                &format!("outcome of {dec}"),
+                "caused",
+                Some("database"),
+                0.8,
+                "rule",
+                1000,
+                Some("positive"),
+                ctx,
+            )
+            .unwrap();
+    }
+    let pairs = store.fork_siblings_for_edges(&[1, 2, 3]).unwrap();
+    assert_eq!(
+        pairs.len(),
+        3,
+        "three same-context decisions ⇒ C(3,2) pairs: {pairs:?}"
+    );
+    // Id-ordered storage.
+    for p in &pairs {
+        assert!(p.edge_id_a < p.edge_id_b);
+        assert!(p.fingerprint.contains("sqlite"));
+        assert!(!p.a_decision.is_empty() && !p.b_decision.is_empty());
+    }
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test invariant: panicking on failure is desired"
+)]
+fn test_no_fork_for_same_decision_rerecord_or_missing_context() {
+    let store = CausalStore::open_in_memory().unwrap();
+    // Same decision text re-recorded in the same context: chunk reuse makes
+    // from_id identical — contradiction territory, NOT a fork.
+    for outcome in ["first try failed", "second try failed"] {
+        store
+            .record_decision_full(
+                "used mysql",
+                outcome,
+                "caused",
+                Some("database"),
+                0.8,
+                "rule",
+                1000,
+                Some("negative"),
+                Some("same context"),
+            )
+            .unwrap();
+    }
+    // Different decisions WITHOUT context: no fingerprint ⇒ no fork logic.
+    for dec in ["used mysql", "used postgres"] {
+        store
+            .record_decision_at(
+                dec,
+                "some outcome",
+                "caused",
+                Some("database"),
+                0.8,
+                "rule",
+                1000,
+            )
+            .unwrap();
+    }
+    let pairs = store.fork_siblings_for_edges(&[1, 2, 3, 4]).unwrap();
+    assert!(pairs.is_empty(), "no pairs expected: {pairs:?}");
+}
+
+#[test]
+#[allow(
+    clippy::unwrap_used,
+    reason = "test invariant: panicking on failure is desired"
+)]
+fn test_fork_lookup_skips_invalidated_edges() {
+    let store = CausalStore::open_in_memory().unwrap();
+    let ctx = Some("shared ctx");
+    store
+        .record_decision_full(
+            "opt A",
+            "worked",
+            "caused",
+            Some("t"),
+            0.9,
+            "rule",
+            1000,
+            Some("positive"),
+            ctx,
+        )
+        .unwrap();
+    let b = store
+        .record_decision_full(
+            "opt B",
+            "broke",
+            "caused",
+            Some("t"),
+            0.9,
+            "rule",
+            2000,
+            Some("negative"),
+            ctx,
+        )
+        .unwrap()
+        .1;
+    assert_eq!(store.fork_siblings_for_edges(&[b]).unwrap().len(), 1);
+    store.invalidate_edge(b).unwrap();
+    assert!(
+        store.fork_siblings_for_edges(&[b]).unwrap().is_empty(),
+        "a pair whose edge was invalidated must not surface"
+    );
 }

--- a/crates/causal-memory/src/store/types.rs
+++ b/crates/causal-memory/src/store/types.rs
@@ -196,3 +196,37 @@ pub struct ForkPair {
     pub b_relation: String,
     pub b_polarity: Option<String>,
 }
+
+/// One still-pending prediction row (v14 ledger, for the report footer).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct PendingPrediction {
+    pub id: i64,
+    pub created_at: i64,
+    pub option_a: String,
+    pub option_b: String,
+    pub task_tag: String,
+    pub method: String,
+}
+
+/// Per-slice (method or task_tag) rollup of resolved predictions.
+/// `correct` counts correct=1 rows only; accuracy = correct / (resolved −
+/// ambiguous) — ambiguous rows resolve but carry no truth value.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct PredictionStatsEntry {
+    pub resolved: i64,
+    pub correct: i64,
+    pub ambiguous: i64,
+}
+
+/// Calibration stats over the prediction ledger (v14): the
+/// counterfactual-honesty dashboard — over time it shows which method is
+/// trustworthy in which stratum.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct PredictionStats {
+    pub resolved: i64,
+    pub correct: i64,
+    pub ambiguous: i64,
+    pub pending: i64,
+    pub by_method: std::collections::HashMap<String, PredictionStatsEntry>,
+    pub by_task_tag: std::collections::HashMap<String, PredictionStatsEntry>,
+}

--- a/crates/causal-memory/src/store/types.rs
+++ b/crates/causal-memory/src/store/types.rs
@@ -168,11 +168,31 @@ pub struct SessionSegment {
     pub task_tag: Option<String>,
     pub hops: Vec<ChainHop>,
 }
-
 /// Cross-session causal chain: multiple session segments linked by
 /// meta-causal edges (pattern-miner bridges).
 #[derive(Debug, Clone, serde::Serialize, schemars::JsonSchema)]
 pub struct CrossSessionChain {
     pub segments: Vec<SessionSegment>,
     pub overall_confidence: f64,
+}
+
+/// A natural experiment (v14, Rung-3 Phase A): two valid edges that share
+/// a context fingerprint but took different decisions. `a`/`b` echo the
+/// id-ordered pair; endpoint texts + polarities are joined in for direct
+/// display. This is same-world-state evidence — stronger for
+/// counterfactuals than pooling cross-context distributions.
+#[derive(Debug, Clone, serde::Serialize, schemars::JsonSchema)]
+pub struct ForkPair {
+    pub pair_id: i64,
+    pub edge_id_a: i64,
+    pub edge_id_b: i64,
+    pub fingerprint: String,
+    pub a_decision: String,
+    pub a_outcome: String,
+    pub a_relation: String,
+    pub a_polarity: Option<String>,
+    pub b_decision: String,
+    pub b_outcome: String,
+    pub b_relation: String,
+    pub b_polarity: Option<String>,
 }

--- a/crates/causal-memory/src/store/types.rs
+++ b/crates/causal-memory/src/store/types.rs
@@ -38,12 +38,19 @@ pub struct CausalEntry {
     /// v8: id of the edge that superseded this one (reversible consolidation).
     /// Non-NULL implies `valid_to` is also set; `restore_edge` clears both.
     pub superseded_by: Option<i64>,
+    /// v14 (Rung-3 Phase A): task_tag + US + normalized context — the
+    /// recorded world state this decision was made in. Same fingerprint ⇒
+    /// comparable branch (see `decision_forks`). None = no context recorded.
+    pub context_fingerprint: Option<String>,
+    /// v14: the raw context description as given (display/audit).
+    pub context_text: Option<String>,
 }
 
 /// Columns selected when materializing a `CausalEntry` (order matters, see `entry_from_row`).
 pub const ENTRY_COLUMNS: &str = "ce.id, cf.id, cf.text, ct.id, ct.text, ce.relation, ce.confidence,
          ce.task_tag, ce.event_time, ce.valid_to, ce.access_count, ce.last_accessed_at,
-         ce.discovered_by, ce.discovered_at, ce.outcome_polarity, ce.superseded_by";
+         ce.discovered_by, ce.discovered_at, ce.outcome_polarity, ce.superseded_by,
+         ce.context_fingerprint, ce.context_text";
 
 /// Map a row selected with `ENTRY_COLUMNS` (plus the standard chunk joins) to a `CausalEntry`.
 pub fn entry_from_row(row: &rusqlite::Row) -> rusqlite::Result<CausalEntry> {
@@ -64,6 +71,8 @@ pub fn entry_from_row(row: &rusqlite::Row) -> rusqlite::Result<CausalEntry> {
         discovered_at: row.get(13)?,
         outcome_polarity: row.get(14)?,
         superseded_by: row.get(15)?,
+        context_fingerprint: row.get(16)?,
+        context_text: row.get(17)?,
     })
 }
 

--- a/crates/causal-memory/src/store/write.rs
+++ b/crates/causal-memory/src/store/write.rs
@@ -8,8 +8,8 @@ use rusqlite::{params, Connection, OptionalExtension};
 
 use super::{
     containment_similarity, date_tokens, effective_polarity, entry_from_row, is_retraction_record,
-    CausalStore, ForkPair, ENTRY_COLUMNS, ID_COUNTER, SUPERSEDES_MIN_SHARED_TOKENS,
-    SUPERSEDES_SIM_THRESHOLD,
+    CausalStore, ForkPair, PendingPrediction, PredictionStats, ENTRY_COLUMNS, ID_COUNTER,
+    SUPERSEDES_MIN_SHARED_TOKENS, SUPERSEDES_SIM_THRESHOLD,
 };
 
 /// One C7 falsification candidate: (old_edge_id, new_edge_id, old_decision,
@@ -950,5 +950,168 @@ impl CausalStore {
             }
         }
         anyhow::bail!("chunk id collision after 4 retries")
+    }
+
+    // ─── v14 prediction ledger (Rung-3 Phase A) ──────────────────────────
+
+    /// Log a counterfactual verdict as a falsifiable prediction. Returns
+    /// the prediction id (the footer reports it). Best-effort by contract:
+    /// the caller (counterfactual_inner) ignores errors so a ledger failure
+    /// never breaks the query itself.
+    pub fn log_prediction(
+        &self,
+        option_a: &str,
+        option_b: &str,
+        task_tag: Option<&str>,
+        verdict: &str,
+        method: &str,
+        confidence: f64,
+        evidence: Option<&str>,
+    ) -> Result<i64> {
+        let conn = self.acquire()?;
+        conn.execute(
+            "INSERT INTO pending_predictions
+             (created_at, option_a, option_b, task_tag, verdict, method, confidence, evidence)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                chrono::Utc::now().timestamp(),
+                option_a,
+                option_b,
+                task_tag,
+                verdict,
+                method,
+                confidence,
+                evidence
+            ],
+        )?;
+        Ok(conn.last_insert_rowid())
+    }
+
+    /// Resolve predictions whose option_a/option_b matches `decision_text`
+    /// (exact text — consistent with chunk-reuse matching). First matching
+    /// record wins: only still-pending rows update, so re-records never
+    /// re-resolve. `correct` semantics (see the design doc §5):
+    ///   prefer_X + took X → 1 iff positive, 0 iff negative, else NULL
+    ///   prefer_X + took Y → 1 iff negative, 0 iff positive, else NULL
+    ///   no_difference     → resolves with NULL (weak evidence either way)
+    /// Returns the number of predictions resolved.
+    pub fn resolve_predictions_for_decision(
+        &self,
+        decision_text: &str,
+        actual_polarity: Option<&str>,
+    ) -> Result<usize> {
+        let conn = self.acquire()?;
+        let now = chrono::Utc::now().timestamp();
+        let mut stmt = conn.prepare(
+            "SELECT id, verdict, option_a, option_b FROM pending_predictions
+             WHERE resolved_at IS NULL AND (option_a = ?1 OR option_b = ?2)",
+        )?;
+        let pending: Vec<(i64, String, String, String)> = stmt
+            .query_map(params![decision_text, decision_text], |r| {
+                Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        drop(stmt);
+        let polarity = actual_polarity.unwrap_or("neutral");
+        let mut n = 0;
+        for (id, verdict, opt_a, _opt_b) in pending {
+            let took_a = opt_a == decision_text;
+            let correct: Option<i64> = match verdict.as_str() {
+                "no_difference" => None,
+                v => {
+                    let preferred_a = v == "prefer_a";
+                    // Followed the preferred option? Correct iff it paid off.
+                    // Took the rejected one? Correct iff it failed.
+                    let followed = preferred_a == took_a;
+                    match polarity {
+                        "positive" => Some((followed) as i64),
+                        "negative" => Some((!followed) as i64),
+                        _ => None, // mixed/neutral actual → ambiguous
+                    }
+                }
+            };
+            conn.execute(
+                "UPDATE pending_predictions
+                 SET resolved_at = ?2, resolved_option = ?3, actual_polarity = ?4, correct = ?5
+                 WHERE id = ?1 AND resolved_at IS NULL",
+                params![id, now, if took_a { "a" } else { "b" }, polarity, correct],
+            )?;
+            n += 1;
+        }
+        Ok(n)
+    }
+
+    /// Calibration stats for `prediction_report`: (resolved, correct,
+    /// ambiguous, pending) overall plus per-method and per-task_tag splits.
+    /// Ambiguous rows (correct IS NULL after resolution) count as resolved
+    /// but excluded from accuracy denominators — reporting them separately
+    /// is the honest read.
+    pub fn prediction_stats(&self) -> Result<PredictionStats> {
+        let conn = self.acquire()?;
+        let pending: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM pending_predictions WHERE resolved_at IS NULL",
+            [],
+            |r| r.get(0),
+        )?;
+        let mut stmt = conn.prepare(
+            "SELECT method, COALESCE(task_tag, ''), COUNT(*),
+                    SUM(CASE WHEN correct = 1 THEN 1 ELSE 0 END),
+                    SUM(CASE WHEN correct IS NULL AND resolved_at IS NOT NULL THEN 1 ELSE 0 END)
+             FROM pending_predictions
+             WHERE resolved_at IS NOT NULL
+             GROUP BY method, COALESCE(task_tag, '')",
+        )?;
+        let rows: Vec<(String, String, i64, i64, i64)> = stmt
+            .query_map([], |r| {
+                Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        let mut stats = PredictionStats {
+            pending,
+            ..PredictionStats::default()
+        };
+        for (method, tag, resolved, correct, ambiguous) in rows {
+            stats.resolved += resolved;
+            stats.correct += correct;
+            stats.ambiguous += ambiguous;
+            let entry = stats.by_method.entry(method).or_default();
+            entry.resolved += resolved;
+            entry.correct += correct;
+            entry.ambiguous += ambiguous;
+            let entry = stats
+                .by_task_tag
+                .entry(if tag.is_empty() {
+                    "(none)".to_string()
+                } else {
+                    tag
+                })
+                .or_default();
+            entry.resolved += resolved;
+            entry.correct += correct;
+            entry.ambiguous += ambiguous;
+        }
+        Ok(stats)
+    }
+
+    /// Recent still-pending predictions for the report footer.
+    pub fn pending_predictions(&self, limit: usize) -> Result<Vec<PendingPrediction>> {
+        let conn = self.acquire()?;
+        let mut stmt = conn.prepare(
+            "SELECT id, created_at, option_a, option_b, COALESCE(task_tag, ''), method
+             FROM pending_predictions WHERE resolved_at IS NULL
+             ORDER BY created_at DESC, id DESC LIMIT ?1",
+        )?;
+        let rows = stmt.query_map(params![limit as i64], |r| {
+            Ok(PendingPrediction {
+                id: r.get(0)?,
+                created_at: r.get(1)?,
+                option_a: r.get(2)?,
+                option_b: r.get(3)?,
+                task_tag: r.get(4)?,
+                method: r.get(5)?,
+            })
+        })?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(Into::into)
     }
 }

--- a/crates/causal-memory/src/store/write.rs
+++ b/crates/causal-memory/src/store/write.rs
@@ -8,7 +8,8 @@ use rusqlite::{params, Connection, OptionalExtension};
 
 use super::{
     containment_similarity, date_tokens, effective_polarity, entry_from_row, is_retraction_record,
-    CausalStore, ENTRY_COLUMNS, ID_COUNTER, SUPERSEDES_MIN_SHARED_TOKENS, SUPERSEDES_SIM_THRESHOLD,
+    CausalStore, ForkPair, ENTRY_COLUMNS, ID_COUNTER, SUPERSEDES_MIN_SHARED_TOKENS,
+    SUPERSEDES_SIM_THRESHOLD,
 };
 
 /// One C7 falsification candidate: (old_edge_id, new_edge_id, old_decision,
@@ -109,8 +110,7 @@ impl CausalStore {
         // the old lesson is falsified by the new evidence — soft-invalidate it.
         // Must run BEFORE inserting the new edge so the new edge is never matched.
         Self::invalidate_contradicted_edges(&conn, decision, outcome, outcome_polarity, db_time)?;
-        let fingerprint = context
-            .map(|c| super::context_fingerprint(task_tag, c));
+        let fingerprint = context.map(|c| super::context_fingerprint(task_tag, c));
         conn.execute(
             "INSERT INTO causal_edges (from_id, to_id, relation, confidence, discovered_by, event_time, discovered_at, task_tag, outcome_polarity, context_fingerprint, context_text)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
@@ -130,7 +130,99 @@ impl CausalStore {
         )?;
         // C3: return the edge id too — callers no longer need a follow-up
         // SELECT to resolve it (the server used to re-query by from_id).
-        Ok((dec_id, conn.last_insert_rowid()))
+        let edge_id = conn.last_insert_rowid();
+        // v14 fork detection (Rung-3 Phase A): same fingerprint + a
+        // DIFFERENT decision chunk ⇒ natural experiment. Best-effort — a
+        // failure here must never fail the record (same discipline as the
+        // embedding path). Cap: link at most the 10 most recent siblings so
+        // a hot fingerprint stays O(n) not O(n²) pairs.
+        if let Some(fp) = &fingerprint {
+            let _ = Self::link_forks(&conn, edge_id, &dec_id, fp, db_time);
+        }
+        Ok((dec_id, edge_id))
+    }
+
+    /// v14: find same-fingerprint siblings with a different decision chunk
+    /// and insert id-ordered fork pairs (UNIQUE-deduped). Same decision text
+    /// re-recorded is the contradiction/supersession path, NOT a fork —
+    /// hence the `from_id !=` guard.
+    fn link_forks(
+        conn: &rusqlite::Connection,
+        edge_id: i64,
+        from_id: &str,
+        fingerprint: &str,
+        db_time: i64,
+    ) -> Result<usize> {
+        let mut stmt = conn.prepare(
+            "SELECT id FROM causal_edges
+             WHERE context_fingerprint = ?1 AND valid_to IS NULL AND from_id != ?2
+             ORDER BY discovered_at DESC, id DESC LIMIT 10",
+        )?;
+        let siblings: Vec<i64> = stmt
+            .query_map(params![fingerprint, from_id], |r| r.get(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        drop(stmt);
+        let mut n = 0;
+        for sib in siblings {
+            let (a, b) = if sib < edge_id {
+                (sib, edge_id)
+            } else {
+                (edge_id, sib)
+            };
+            n += conn.execute(
+                "INSERT OR IGNORE INTO decision_forks (edge_id_a, edge_id_b, fingerprint, discovered_at)
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![a, b, fingerprint, db_time],
+            )?;
+        }
+        Ok(n)
+    }
+
+    /// v14: fork pairs touching any of `edge_ids`, joined to both edges'
+    /// endpoint texts and polarities (for the counterfactual same-context
+    /// section). Only pairs where BOTH edges are still valid are returned.
+    pub fn fork_siblings_for_edges(&self, edge_ids: &[i64]) -> Result<Vec<ForkPair>> {
+        if edge_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let conn = self.acquire()?;
+        let placeholders = vec!["?"; edge_ids.len()].join(",");
+        let mut stmt = conn.prepare(&format!(
+            "SELECT f.id, f.edge_id_a, f.edge_id_b, f.fingerprint,
+                    da.text, oa.text, ea.relation, ea.outcome_polarity,
+                    db.text, ob.text, eb.relation, eb.outcome_polarity
+             FROM decision_forks f
+             JOIN causal_edges ea ON ea.id = f.edge_id_a AND ea.valid_to IS NULL
+             JOIN causal_edges eb ON eb.id = f.edge_id_b AND eb.valid_to IS NULL
+             JOIN chunks da ON da.id = ea.from_id
+             JOIN chunks oa ON oa.id = ea.to_id
+             JOIN chunks db ON db.id = eb.from_id
+             JOIN chunks ob ON ob.id = eb.to_id
+             WHERE f.edge_id_a IN ({placeholders}) OR f.edge_id_b IN ({placeholders})"
+        ))?;
+        let bind: Vec<&dyn rusqlite::ToSql> = edge_ids
+            .iter()
+            .chain(edge_ids.iter())
+            .map(|i| i as &dyn rusqlite::ToSql)
+            .collect();
+        let rows = stmt.query_map(bind.as_slice(), |row| {
+            Ok(ForkPair {
+                pair_id: row.get(0)?,
+                edge_id_a: row.get(1)?,
+                edge_id_b: row.get(2)?,
+                fingerprint: row.get(3)?,
+                a_decision: row.get(4)?,
+                a_outcome: row.get(5)?,
+                a_relation: row.get(6)?,
+                a_polarity: row.get(7)?,
+                b_decision: row.get(8)?,
+                b_outcome: row.get(9)?,
+                b_relation: row.get(10)?,
+                b_polarity: row.get(11)?,
+            })
+        })?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(Into::into)
     }
     /// C7 update-resolver candidate scan: valid edges whose decision chunk
     /// is REUSED (exact same decision text — record_decision reuses chunks)

--- a/crates/causal-memory/src/store/write.rs
+++ b/crates/causal-memory/src/store/write.rs
@@ -64,13 +64,18 @@ impl CausalStore {
             discovered_by,
             event_time,
             None,
+            None,
         )
     }
 
-    /// Record with an explicit event_time and a pre-judged outcome polarity
+    /// Record with an explicit event_time, a pre-judged outcome polarity
     /// (v4: positive/negative/mixed/neutral, judged by the LLM or the
-    /// heuristic at the caller). `None` stores NULL — read paths then fall
-    /// back to the signal-word heuristic.
+    /// heuristic at the caller), and an optional decision context
+    /// (v14: the world state the decision was made in — the abduction
+    /// substrate; same task_tag+context ⇒ comparable branch).
+    /// `None` polarity stores NULL — read paths then fall back to the
+    /// signal-word heuristic. `None` context stores NULL — legacy
+    /// behavior, excluded from fork detection.
     #[allow(clippy::too_many_arguments)]
     pub fn record_decision_full(
         &self,
@@ -82,6 +87,7 @@ impl CausalStore {
         discovered_by: &str,
         event_time: i64,
         outcome_polarity: Option<&str>,
+        context: Option<&str>,
     ) -> Result<(String, i64)> {
         let conn = self.acquire()?;
         let db_time = chrono::Utc::now().timestamp();
@@ -103,10 +109,24 @@ impl CausalStore {
         // the old lesson is falsified by the new evidence — soft-invalidate it.
         // Must run BEFORE inserting the new edge so the new edge is never matched.
         Self::invalidate_contradicted_edges(&conn, decision, outcome, outcome_polarity, db_time)?;
+        let fingerprint = context
+            .map(|c| super::context_fingerprint(task_tag, c));
         conn.execute(
-            "INSERT INTO causal_edges (from_id, to_id, relation, confidence, discovered_by, event_time, discovered_at, task_tag, outcome_polarity)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-            params![&dec_id, &out_id, relation, confidence, discovered_by, event_time, db_time, task_tag, outcome_polarity],
+            "INSERT INTO causal_edges (from_id, to_id, relation, confidence, discovered_by, event_time, discovered_at, task_tag, outcome_polarity, context_fingerprint, context_text)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+            params![
+                &dec_id,
+                &out_id,
+                relation,
+                confidence,
+                discovered_by,
+                event_time,
+                db_time,
+                task_tag,
+                outcome_polarity,
+                fingerprint,
+                context
+            ],
         )?;
         // C3: return the edge id too — callers no longer need a follow-up
         // SELECT to resolve it (the server used to re-query by from_id).

--- a/docs/design/counterfactual-rung3.md
+++ b/docs/design/counterfactual-rung3.md
@@ -1,0 +1,254 @@
+# Counterfactual Rung 3 — Design
+
+> Status: **Phase A implementing** (2026-09-01). Prior art:
+> [research/computational-ai/rung3-prior-art.md](../research/computational-ai/rung3-prior-art.md).
+>
+> One-line thesis: Pearl's third rung needs **abduction** (conditioning on
+> the recorded world state), a **mechanism model**, and — to be science
+> rather than imagination — **falsification by future branches**. We cannot
+> reach SCM ground truth in open worlds, but we can build the complete
+> engineering subset: record what abduction needs, link the natural
+> experiments we already accumulate, make every counterfactual claim a
+> logged prediction, and rerun literally where the world is code.
+
+## 1. Where we are on the ladder
+
+| Rung | Tool | What it actually computes |
+|---|---|---|
+| R1 association | `search_causal` | P(outcome \| similar decision) from recorded edges |
+| R2 intervention | `intervention_query` | Empirical do-effects: forward chains from similar past actions, task_tag stratification, Simpson warning |
+| R3-lite | `counterfactual_query` | Contrastive A/B outcome distributions — but the two sides' evidence comes from **different, unmodeled contexts**; there is no abduction |
+
+The gap is structural, not parametric: `P(Y_x | X=x', Y=y', C)` requires a
+recorded `C`. Executable Counterfactuals (arXiv:2510.01539) measured the
+same gap in SOTA LLMs (−25–40% when abduction is enforced). Our plan adds
+`C` (Phase 0), links same-`C` branches (Phase 1), converts claims into
+testable predictions (Phase 2), and reruns `C` where it is executable
+(Phase 4 interface).
+
+## 2. Phases
+
+Implementation order and rationale:
+
+| Phase | Name | Ships | Status |
+|---|---|---|---|
+| 0 | Abduction substrate | `context` param → `causal_edges.context_fingerprint/context_text` (schema v14) | **this PR** |
+| 1 | Natural-experiment graph | write-time `decision_forks` pairs; fork-aware `counterfactual_query` | **this PR** |
+| 2 | Prediction ledger | `pending_predictions` + auto-resolution on record + `prediction_report` (17th tool) | **this PR** |
+| 3 | Estimation & simulation | micro-SCM (noisy-OR over `{caused, enabled, prevented}`) and LLM replay with identifiability gates | deferred (needs fork density) |
+| 4 | Executable replay | closed-world task_tags route to a replay plan; result feeds the ledger | interface only |
+
+Phases 0/1/2 are cheap, unconditionally useful, and prerequisite for
+everything else. Phase 3 waits until the fork graph is dense enough to
+fit mechanisms (watch metric: fork pairs per task_tag). Phase 4 has a
+working external engine (stepback's dirty-set replay) — we define the
+interface and route, we do not build a trace format yet.
+
+## 3. Phase 0 — abduction substrate (schema v14)
+
+### Schema
+
+```sql
+ALTER TABLE causal_edges ADD COLUMN context_fingerprint TEXT;
+ALTER TABLE causal_edges ADD COLUMN context_text TEXT;
+CREATE INDEX IF NOT EXISTS idx_causal_fingerprint
+    ON causal_edges(context_fingerprint) WHERE context_fingerprint IS NOT NULL;
+```
+
+- `context_fingerprint` — `task_tag + "\x1f" + normalize(context)` where
+  `normalize` = lowercase + collapse runs of whitespace. Stored as the
+  normalized string itself (not a hash): greppable, debuggable, indexable.
+  `NULL` = no context recorded (legacy behavior, excluded from fork logic).
+- `context_text` — the raw context description as given (audit/display).
+
+### Write path
+
+- `CausalStore::record_decision_full` gains `context: Option<&str>`.
+  `record_decision_at` (test/bench helper) passes `None` — unchanged
+  signature.
+- MCP `record_decision` gains optional `context` param: *"Short
+  description of the situation the decision was made in (environment,
+  constraints, key parameters). Records with the same task_tag + context
+  become comparable branches."* Agents that don't send it lose nothing.
+- `CausalEntry` carries both fields through (`ENTRY_COLUMNS` +1 each).
+- Soft-invalidation, supersession, GC, sleep: untouched — the new columns
+  ride along on the existing edge lifecycle.
+
+## 4. Phase 1 — natural-experiment graph (`decision_forks`)
+
+```sql
+CREATE TABLE IF NOT EXISTS decision_forks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    edge_id_a INTEGER NOT NULL,   -- lower edge id
+    edge_id_b INTEGER NOT NULL,   -- higher edge id
+    fingerprint TEXT NOT NULL,    -- shared context_fingerprint
+    discovered_at INTEGER NOT NULL,
+    UNIQUE(edge_id_a, edge_id_b),
+    FOREIGN KEY (edge_id_a) REFERENCES causal_edges(id),
+    FOREIGN KEY (edge_id_b) REFERENCES causal_edges(id)
+);
+CREATE INDEX IF NOT EXISTS idx_forks_a ON decision_forks(edge_id_a);
+CREATE INDEX IF NOT EXISTS idx_forks_b ON decision_forks(edge_id_b);
+```
+
+### Semantics
+
+A fork pair = two **valid** edges sharing a context fingerprint whose
+decision chunks differ (`from_id` different). Same decision text re-recorded
+with a different outcome is the contradiction/supersession path, not a
+fork. Pair is stored id-ordered; `INSERT OR IGNORE` dedups.
+
+### Write-time detection (inside `record_decision_full`)
+
+After inserting edge E with fingerprint F:
+
+1. `SELECT` valid edges with fingerprint F, `from_id != E.from_id`, ordered
+   by `discovered_at DESC`, **capped at 10** (guards against n² blowup on
+   hot fingerprints).
+2. Insert pairs `(min(id,E), max(id,E))` for each.
+
+Detection failure never blocks recording (best-effort, like embedding).
+
+### Fork-aware `counterfactual_query`
+
+Unchanged comparison first (backward-compatible output), then an extra
+section when fork evidence exists:
+
+```
+🔀 Same-context branches (natural experiments, n pairs):
+  [ctx] …fingerprint…
+    A: "used mysql" →(caused)→ "migration locks" [negative]
+    B: "used postgres" →(caused)→ "clean cutover" [positive]
+```
+
+Implementation: after both `side_evidence` retrievals, for each retrieved
+edge look up its fork siblings (`fork_siblings_for_edges`); a sibling whose
+decision text is also retrieved on the *other* side renders as a paired
+row. Same-context pairs outweigh aggregate distributions in the verdict
+ordering (a fork pair is evidence about one world; distributions are
+evidence about many) — the verdict function takes paired evidence first,
+falls back to distribution diff. Pairs also render standalone (sibling not
+on the other side) at reduced weight, since they still pin the context.
+
+## 5. Phase 2 — prediction ledger
+
+```sql
+CREATE TABLE IF NOT EXISTS pending_predictions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    created_at INTEGER NOT NULL,
+    option_a TEXT NOT NULL,          -- decision text as queried
+    option_b TEXT NOT NULL,          -- alternative text as queried
+    task_tag TEXT,
+    verdict TEXT NOT NULL,           -- 'prefer_a' | 'prefer_b' | 'no_difference'
+    method TEXT NOT NULL,            -- 'contrastive' (later: micro_scm | llm_sim | executable)
+    confidence REAL NOT NULL,        -- evidence strength at prediction time
+    evidence TEXT,                   -- compact JSON snapshot (dists, fork count)
+    resolved_at INTEGER,             -- NULL = pending
+    resolved_option TEXT,            -- 'a' | 'b' — which option reality took
+    actual_polarity TEXT,            -- observed outcome polarity
+    correct INTEGER                  -- 1/0; NULL = ambiguous (mixed/neutral actual)
+);
+```
+
+### Logging
+
+Every `counterfactual_query` writes one pending row (best-effort; failures
+never break the query). Output gains a footer:
+`📐 Prediction #N logged — resolved automatically when either option is recorded.`
+
+### Resolution (automatic, inside `record_decision`)
+
+When an edge is recorded whose `decision_text` equals a pending
+prediction's `option_a` or `option_b` (exact-text match — consistent with
+chunk reuse semantics):
+
+- `resolved_option` = which side matched; `actual_polarity` = the edge's
+  stored polarity.
+- `correct`:
+  - verdict `prefer_X`, reality took X → correct iff polarity = positive
+    (negative ⇒ wrong; mixed/neutral ⇒ NULL, ambiguous).
+  - verdict `prefer_X`, reality took the other → correct iff polarity =
+    negative (it turned out X's rival failed — the preference was right);
+    positive ⇒ 0; mixed/neutral ⇒ NULL.
+  - `no_difference` → resolves with correct=NULL (evidence about either
+    branch is weak evidence about indifference).
+- A prediction resolves **once** (first matching record wins); later
+  re-records of the same option don't re-resolve (they're supersession
+  territory).
+
+### `prediction_report` (17th MCP tool, read-only)
+
+```
+📐 Prediction ledger: 3 resolved / 5 pending (method=contrastive)
+   accuracy 2/2 (100%, 1 ambiguous excluded)
+   by task_tag: causal-memory 2/2 · debugging 0/0
+   pending: #4 "reuse main model" vs "small dedicated model" (causal-memory, 2026-09-01)
+```
+
+Per-method and per-task_tag accuracy, pending list with ages. This is the
+calibration loop's dashboard — over time it tells us which R3 method is
+trustworthy where. Python binding mirrors it (`prediction_report()`).
+
+## 6. Phase 3 (deferred) — estimation & simulation
+
+Trigger: ≥ 30 fork pairs within one task_tag stratum. Then:
+
+1. **Micro-SCM**: fit noisy-OR/noisy-AND-NOT gates over
+   `{caused, enabled, prevented}` → outcome polarity classes, per stratum,
+   EM from recorded edges; query = abduction (posterior over context
+   variables given the observed episode) → action (swap the decision
+   node's mechanism) → prediction. Identifiability gate à la cfid: when
+   the stratum's fork density is too low, answer "not identifiable —
+   degrading to contrastive" (labels: point / set / not-identifiable).
+2. **LLM replay** (`counterfactual_simulate`): retrieve the episode's
+   full context snapshot + trajectory, ask the LLM to re-run with the
+   alternative; score with the `reconstruct_lesson --calibrate` agreement
+   mechanism; label `confidence_source: llm_inferred`; predictions from
+   this path enter the ledger with `method='llm_sim'` so calibration can
+   separate its trust level from contrastive's.
+
+## 7. Phase 4 (interface) — executable replay
+
+`counterfactual_query` output routes closed-world task_tags (build / test /
+config / bench) to a replay plan:
+
+```
+🧪 This looks like a closed-world decision (task_tag=build).
+   Instead of estimating: replay it. Plan:
+   1. Locate the recorded outcome edge (#123, event_time …)
+   2. Apply the alternative as a patch/flag in a sandbox
+   3. Execute; record result with record_decision(…, context=<same>)
+   → the prediction ledger resolves automatically.
+```
+
+The engine (stepback-style trace + dirty-set replay) is future work; the
+routing, the plan template, and the ledger feedback path are defined now
+so `method='executable'` rows can exist from day one.
+
+## 8. Test plan
+
+Unit (store): fingerprint normalization; migration v13→v14 (column adds
++ idempotent re-run); fork pair creation on second distinct decision in
+same context; no fork on same-text re-record; pair cap; fork lookup by
+edge ids.
+
+Unit (memory facade): `record_decision` with context stores both columns;
+`counterfactual_query` renders fork section when present, footer always;
+prediction row logged per query; resolution matrix (verdict × taken option
+× polarity → correct value); `no_difference` → NULL; single resolution;
+`prediction_report` math (accuracy excludes ambiguous; per-tag split).
+
+Regression: byte-identical `counterfactual_query` output when no forks
+exist and ledger write fails open; `record_decision` without context
+param unchanged; migration e2e on a v13 fixture DB; full
+`cargo test --workspace`; PyO3 smoke (new `record_decision(context=…)`,
+`counterfactual_query`, `prediction_report`).
+
+## 9. Non-goals
+
+- No SCM ground-truth claims in open worlds — every output keeps its
+  honesty label; the ladder is "recorded-evidence → paired-evidence →
+  gated-estimate → replayed-fact".
+- No LLM dependency in Phases 0/1/2 (deterministic; hermetic tests).
+- No change to edge lifecycle (invalidation/supersession/GC/sleep) or to
+  retrieval ranking.

--- a/docs/design/counterfactual-rung3.md
+++ b/docs/design/counterfactual-rung3.md
@@ -130,6 +130,15 @@ evidence about many) — the verdict function takes paired evidence first,
 falls back to distribution diff. Pairs also render standalone (sibling not
 on the other side) at reduced weight, since they still pin the context.
 
+**Known limitation (found while testing)**: `side_evidence` retrieves on
+decision AND outcome text, so two options that share vocabulary (e.g.
+"use the main model" vs "use a small model" — and outcomes that share
+words like "migration") contaminate each other's pools, flattening the
+distribution contrast toward a tie. Fork pairs are immune (they compare
+recorded same-context branches, not query-side pools). Competitive
+separation — dropping from each side the entries the other side ranks
+higher — is a Phase-3 refinement.
+
 ## 5. Phase 2 — prediction ledger
 
 ```sql

--- a/docs/research/computational-ai/README.md
+++ b/docs/research/computational-ai/README.md
@@ -12,6 +12,7 @@
 | [Park et al. — Generative Agents](generative-agents.md) | 2023 | Multi-day agent simulation with memory streams | Memory stream + reflection as closest precedent |
 | [Goyal & Bengio — System 2 Inductive Biases](system2-explicit-representation.md) | 2022 | System 2 cognition needs explicit representations | Externalizing causal structure into explicit graph |
 | [Hermes Agent — memory provider ecosystem](hermes-provider-ecosystem.md) | 2026 | First agent runtime with a first-class memory plugin slot (ecosystem analysis, not a paper) | Distribution channel identification; hybrid recall-mode design; PyO3 reprioritization |
+| [Rung-3 Prior Art survey](rung3-prior-art.md) | 2026 | Counterfactual reasoning: papers + engineering between us and Pearl's third rung | The five-phase Rung-3 plan (context snapshots → fork edges → micro-SCM → simulation → executable replay + prediction ledger) |
 
 ---
 

--- a/docs/research/computational-ai/rung3-prior-art.md
+++ b/docs/research/computational-ai/rung3-prior-art.md
@@ -1,0 +1,142 @@
+# Rung-3 Prior Art — Counterfactual Reasoning for Agent Memory (2026 survey)
+
+> Web survey conducted 2026-09-01 (GitHub live search + Semantic Scholar +
+> direct abstract fetches; arXiv API unreachable from this network — every
+> item below was verified against its repo or abstract page).
+>
+> Context: `counterfactual_query` (v0.9) is an honestly-labeled contrastive
+> comparison, NOT a Pearl Rung-3 counterfactual. This survey maps what
+> exists between us and the real third rung, and which parts already have
+> algorithms or engineering we can borrow.
+
+## Why the gap is real: Executable Counterfactuals
+
+**Vashishtha et al. (2025) — "Executable Counterfactuals"
+([arXiv:2510.01539](https://arxiv.org/abs/2510.01539), code:
+[AniketVashishtha/Executable_Counterfactuals](https://github.com/AniketVashishtha/Executable_Counterfactuals))**
+
+Operationalizes counterfactual reasoning as code/math problems that force
+all three Pearl steps: **abduction → intervention → prediction**. Key
+findings:
+
+- Existing LLM counterfactual evaluations largely **skip the abduction
+  step**, which reduces them to interventional (Rung-2) reasoning and
+  overestimates capability.
+- SOTA models (o4-mini, Claude-4-Sonnet) drop **25–40% accuracy** moving
+  from interventional to true counterfactual problems.
+- RL on counterfactual code problems induces transferable counterfactual
+  skill; SFT does not (gains in-domain, loses out-of-domain).
+
+**Design relevance**: this is external, measured confirmation of our own
+code comment (`ops.rs`: "NOT a Pearl Rung-3 SCM counterfactual") — the
+missing ingredient is *abduction*, i.e. conditioning on the recorded world
+state of the actual episode. It also supplies a synthetic-data recipe for
+building a Rung-3 eval set.
+
+## The five-rungette ladder (what we can actually build)
+
+Full design: [docs/design/counterfactual-rung3.md](../../design/counterfactual-rung3.md).
+Each phase has prior art:
+
+### Abduction substrate (context snapshots)
+
+No external dependency needed — schema work. The survey found no agent
+memory system that records a structured pre-decision context fingerprint;
+this is greenfield (and the prerequisite Pearl's math demands:
+P(Y_x | X=x', Y=y', C) needs a recorded C).
+
+### Natural-experiment graph (fork edges)
+
+- **FlowScript → anneal-memory**
+  ([phillipclapham/flowscript](https://github.com/phillipclapham/flowscript),
+  archived, evolved into
+  [anneal-memory](https://github.com/phillipclapham/anneal-memory)):
+  a 21-marker notation where `||` (alternatives) is a first-class marker,
+  with `why` / `whatIf` / `counterfactual` typed queries over reasoning
+  graphs (TS SDK + MCP server). Validates "alternatives as first-class
+  graph structure" for agent memory.
+- **counterfactual-research**
+  ([osobot-ai/counterfactual-research](https://github.com/osobot-ai/counterfactual-research),
+  adapted from karpathy/autoresearch): an autonomous-research harness
+  asking exactly our question — *does structured counterfactual memory
+  build a better world model faster than episodic memory?* Its environment
+  reveals outcomes for **chosen AND unchosen** options ("natural
+  counterfactuals"), and its headline metric `counterfactual_accuracy`
+  (how well the agent predicts outcomes of paths not taken) is precisely
+  the calibration metric our prediction ledger needs.
+
+### Statistical micro-SCM (abduction-action-prediction over the recorded graph)
+
+- **DeepSCM** ([biomedia-mira/deepscm](https://github.com/biomedia-mira/deepscm),
+  297★): Pawlowski et al., *Deep Structural Causal Models for Tractable
+  Counterfactual Inference* — normalizing flows + VAE doing full
+  abduction-action-prediction. The algorithmic blueprint for when our
+  fork graph gets dense.
+- **DoWhy GCM counterfactuals**
+  ([user guide](https://github.com/py-why/dowhy/blob/main/docs/source/user_guide/causal_tasks/what_if/counterfactuals.rst),
+  medical case notebook): the mainstream causal library's AAP API — the
+  interface semantics worth mirroring (fit → abduce → intervene → predict).
+- **cfid** ([santikka/cfid](https://github.com/santikka/cfid), R/CRAN):
+  implements Shpitser-style **counterfactual identifiability** (ID*/shortcut):
+  decides whether a counterfactual query is computable from a given causal
+  graph + data at all. This is the engine for our "not identifiable →
+  degrade to contrastive" gate.
+- **counterfactual-identifiability-bench**
+  ([zackary-masri](https://github.com/zackary-masri/counterfactual-identifiability-bench)):
+  10k executable counterfactual problems labeled by identifiability
+  (**point / set / not-identifiable**). The label taxonomy to adopt for
+  R3 answers.
+
+### LLM world-model simulation (Gerstenberg counterfactual simulation)
+
+Gerstenberg et al. (2021) — already in
+[research-backdrop](../research-backdrop.zh.md); no canonical code, but
+`reconstruct_lesson --calibrate=N` already implements the
+multi-reconstruction-agreement scoring a simulator needs. Executable
+Counterfactuals (above) is the benchmark to beat.
+
+### Executable replay (the one true SCM counterfactual available to agents)
+
+- **stepback** ([thehalleyyoung/stepback](https://github.com/thehalleyyoung/stepback)):
+  a time-travel debugger for agent runs. Records a run as a signed
+  (HMAC-SHA256 + Ed25519) `.sb` trace of content-addressed steps;
+  a substitution (tool output, system prompt, routing branch) replays
+  through the dependency graph with **dirty-set propagation** — only
+  downstream steps re-execute — plus bisection to find where the
+  counterfactual run diverges. This is a working engine for closed-world
+  counterfactuals (builds, tests, sandboxes): rerun history *literally*.
+  Our `recall_audit` table is already the embryo of a step trace.
+- **llm-counterfactual-replay**
+  ([zizhao-hu](https://github.com/zizhao-hu/llm-counterfactual-replay)):
+  conversation fork + counterfactual memory edits, then replay — the
+  lightweight variant.
+
+## Adjacent (worth knowing, not core)
+
+- **restore-counterfactual**
+  ([megagonlabs](https://github.com/megagonlabs/restore-counterfactual),
+  CBW@COLM 2026): *What Eviction Destroys* — restore-counterfactual
+  audit of forgetting in agent memory. Directly applicable to auditing
+  our own GC / sleep eviction policy.
+- **regret-eval** ([4Lou4](https://github.com/4Lou4/regret-eval)): offline
+  evaluation of never-executed policies (posterior oracle, regret,
+  temporal splits) — statistics reference for the prediction ledger.
+- **Counterfactual-Memory-Auditing-for-Long-Term-Agents**
+  ([TylorChan](https://github.com/TylorChan/Counterfactual-Memory-Auditing-for-Long-Term-Agents)):
+  auditing whether agents *causally use* the memory they retrieve.
+- **DreamArbiter**: lucid-dreaming cycles that generate counterfactuals
+  during "sleep" — a cousin of our SWR consolidation loop.
+- **alibi** (SeldonIO, 2.6k★): counterfactual *explanations* /
+  algorithmic recourse (CFGP, CEM). Different sense of "counterfactual"
+  (input perturbation for XAI), but recourse-style search is a plausible
+  future advisor for "what should I have done differently".
+
+## Competitive read
+
+Nobody combines **recorded abduction context + fork graph +
+identifiability-gated estimation/simulation + a prediction ledger + closed-
+world executable replay** in one agent memory system. Adjacent projects
+each own one corner (stepback: replay; anneal-memory: alternatives in the
+graph; counterfactual-research: the eval protocol). The window is open
+but visibly closing — this survey found four 2026-dated repos whose
+descriptions overlap our design doc's phases.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -204,6 +204,13 @@ Memory-quality:
   (today an external caller must still start `sleep`)
 - [ ] **LLM update-resolver**: replace rule-based contradiction detection
   with the LLM judge for invalidation decisions (polarity plumbing ready)
+- [ ] **Rung-3 Phase A (abduction + forks + prediction ledger)** —
+  [design](design/counterfactual-rung3.md): context fingerprints on
+  `record_decision` (schema v14), write-time `decision_forks` natural
+  experiments, `counterfactual_query` fork section + logged predictions
+  auto-resolved by later `record_decision` calls, `prediction_report`
+  (17th tool) calibration dashboard. Phase B (micro-SCM / LLM replay)
+  gated on fork density; Phase C (executable replay) interface-routed
 - [x] **Meta-edge invalidation tool** — ✅ shipped 2026-08-24
   (`invalidate_pattern`, 16th MCP tool): soft-deletes via the existing
   `meta_causal_edges.valid_to` (readers already filtered it), live graph
@@ -258,10 +265,19 @@ Ecosystem:
 
 ## Explicitly out of scope
 
-- **Rung 3 SCM counterfactuals** (structural-causal-model reasoning): per
-  [insights/11](https://github.com/JingxuanC/agent-teardown/blob/main/insights/11-causal-state-store.md),
-  practically impossible for agents. The honest engineering subset shipped:
-  `counterfactual_query` is contrastive/empirical over recorded
-  alternatives, labeled as such on every output.
-  *Watch: Executable Counterfactuals (arXiv:2510.01539) challenges this;
-  revisit if the technique matures.*
+- **Rung-3 SCM ground truth** (structural-causal-model certainty in open
+  worlds): per
+  [insights/11](https://github.com/JingxuanC/causal-memory/blob/main/insights/11-causal-state-store.md),
+  not achievable for agents acting in open, nonstationary worlds. The R3
+  **engineering subset** is in scope since 2026-09-01 — see
+  [docs/design/counterfactual-rung3.md](design/counterfactual-rung3.md)
+  and the prior-art survey
+  ([research/computational-ai/rung3-prior-art.md](research/computational-ai/rung3-prior-art.md)):
+  abduction substrate (context fingerprints, schema v14) → fork edges
+  (natural-experiment graph) → prediction ledger (counterfactual_query
+  logs falsifiable predictions, auto-resolved when either branch is
+  recorded) → deferred micro-SCM/LLM replay (gated on fork density) →
+  closed-world executable replay (stepback-style rerun; interface only).
+  *Watch: Executable Counterfactuals (arXiv:2510.01539) confirmed the
+  abduction gap is real and measurable — its synthetic-data recipe is the
+  candidate eval set when Phase 3 starts.*

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -96,12 +96,13 @@ Mechanism absorption (from the 2026-07-30 deep dives, deduplicated):
 
 ## Current state — v0.9.0+ (main)
 
-**Sixteen MCP tools**: `record_decision` / `search_causal` / `record_fact` /
+**Seventeen MCP tools**: `record_decision` / `search_causal` / `record_fact` /
 `search_facts` / `search_memory` / `trace_cause` / `trace_cause_chain` /
 `invalidate_decision` / `invalidate_pattern` / `resolve_updates` /
 `search_patterns` / `causal_directory` / `intervention_query` /
-`counterfactual_query` / `reconstruct_lesson` / `remember` — over stdio
-**and** HTTP transport (`causal-memory-http --port 9938`).
+`counterfactual_query` / `reconstruct_lesson` / `remember` /
+`prediction_report` — over stdio **and** HTTP transport
+(`causal-memory-http --port 9938`).
 
 Core capabilities (all shipped, all tested):
 


### PR DESCRIPTION
## Summary

Rung-3 反事实工程子集的第一批落地（Phase A），从 "explicitly out of scope" 转为分阶段实施。含调研、设计文档与完整实现。

### 文档
- `docs/research/computational-ai/rung3-prior-art.md` — 先行者调研（Executable Counterfactuals / stepback / DeepSCM / DoWhy / cfid / counterfactual-research，含竞品分析）
- `docs/design/counterfactual-rung3.md` — 五阶段设计：溯因底座 → fork 图 → 预测账本 →（延迟）micro-SCM/LLM 模拟 → 可执行重放
- `docs/roadmap.md` — R3 条目改写；16 → 17 工具

### 实现（schema v13 → v14，四个 commit）
| Commit | 内容 |
|---|---|
| Phase 0 | `record_decision` 新增可选 `context` 参数（MCP + Python）；`context_fingerprint/context_text` 列 + 部分索引；一次迁移铺全 Phase A 表结构 |
| Phase 1 | 写入时 fork 检测：同指纹 + 不同决策 ⇒ `decision_forks` 自然实验对（限流防 n²）；`counterfactual_query` 新增 🔀 同境分支段落，成对判定优先于跨境分布聚合 |
| Phase 2+4 | 预测账本 `pending_predictions`：每次 verdict 落账，后续 record 自动结算（判定矩阵见设计文档 §5）；`prediction_report` 第 17 个工具（按方法/task_tag 校准统计）；封闭域 tag（build/test/config/bench）路由到重放计划 |
| fix | 成对判定 "favor/favors" 措辞不匹配致账本恒 ambiguous（Python e2e 拦截）；fork 端点标签；main 上既有 `remember` 过时断言修复 |

## Test plan

- [x] `cargo test --workspace`：430 passed / 0 failed（含 17 个新测试：指纹归一化、fork 语义、结算矩阵 6 例、统计聚合、e2e log→resolve→report、封闭域路由开关）
- [x] Python smoke：18/18（maturin 构建，含新 context/账本 e2e）
- [x] clippy 干净 / rustfmt 已过
- [x] 迁移幂等（v13 夹具 + 部分夹具库守卫）
- [x] 无 context 时 `counterfactual_query` / `record_decision` 输出形态兼容（回归测试覆盖）

## Known limitations（写入设计文档）
- 同域选项共享词汇时 BM25 双边互相污染（决策+结果一起检索），分布对比趋平——fork 对不受影响；竞争性分离留 Phase 3
- 结算依赖写入时极性判定的信号词/LLM，模糊结果诚实计为 ambiguous 并从准确率分母排除

🤖 Generated with [Grok Build](https://grok.com/build)