### PR TITLE
feat(plugins): native Claude Code plugin + marketplace, Codex slash prompt

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "causal-memory",
+  "description": "Persistent causal memory for coding agents — decisions, outcomes, lessons, same-context counterfactuals, and a falsifiable prediction ledger. Shared across Claude Code, Codex, kimi, Hermes, and Python.",
+  "owner": {
+    "name": "JingxuanC"
+  },
+  "plugins": [
+    {
+      "name": "causal-memory",
+      "description": "Persistent causal memory for Claude Code — decisions, outcomes, and lessons that survive compaction. Same-context counterfactuals (natural experiments), a falsifiable prediction ledger, and an activation skill that teaches when to recall and record.",
+      "author": {
+        "name": "JingxuanC"
+      },
+      "category": "memory",
+      "source": "./plugins/claude-code",
+      "homepage": "https://github.com/JingxuanC/causal-memory"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.9.3] - Unreleased
 
 ### Added
+- **Native Claude Code plugin + marketplace** (`plugins/claude-code/` +
+  root `.claude-plugin/marketplace.json`): install with
+  `claude plugin marketplace add JingxuanC/causal-memory &&
+  claude plugin install causal-memory@causal-memory`. Ships the MCP server
+  (stdio from PATH), the activation skill, `/recall <task>` (experience
+  check before acting) and `/memory-report` (prediction-ledger calibration
+  + inventory). Verified locally: marketplace add → install → `✔
+  Connected`, ~229-token always-on cost. Prerequisite: `pip install
+  causal-memory` (or build from repo and put the binary on PATH).
+- **Codex native surface** (`plugins/codex/prompts/causal-memory.md`):
+  `/causal-memory <task>` custom prompt; `integrations/codex` installer
+  now installs it alongside the MCP registration + AGENTS.md guidance.
 - **Rung-3 activation pass** (post-Phase-A): all five integration surfaces
   now teach the `context` param and `prediction_report` (Claude.md paste
   prompt, SKILL.md, dsh-plugin system prompt + README, Hermes provider

--- a/README.md
+++ b/README.md
@@ -231,6 +231,10 @@ cargo build --release
 
 ### MCP integration (Claude Code, Cursor, grok-build, etc.)
 
+First-class installers: **Claude Code** (`integrations/claude-code/`) and
+**Codex CLI** (`integrations/codex/`) — MCP registration + activation
+prompt/skill in one idempotent script each.
+
 ```json
 {
   "mcpServers": {

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -1,0 +1,56 @@
+# Claude Code integration
+
+**Preferred: the native plugin** (marketplace install — see
+`plugins/claude-code/`):
+
+```bash
+pip install causal-memory                      # binary on PATH
+claude plugin marketplace add JingxuanC/causal-memory
+claude plugin install causal-memory@causal-memory
+```
+
+The script below is the no-marketplace fallback (direct MCP registration
++ skill copy).
+
+## What it wires up
+
+1. **MCP server**: `causal-memory` (stdio, no args). All 17 tools:
+   `record_decision` (with `context`) / `search_memory` /
+   `counterfactual_query` / `prediction_report` / …
+2. **Skill**: `~/.claude/skills/causal-memory/SKILL.md` — teaches Claude
+   Code WHEN to call the tools (before non-trivial decisions, when choosing
+   between options, after observing outcomes, ALWAYS record `context` when
+   multiple options were weighed).
+
+## Install
+
+```bash
+./install.sh            # uses target/release/causal-memory by default
+BIN=/other/path ./install.sh
+```
+
+Verify:
+
+```bash
+claude mcp list         # causal-memory must appear and connect
+```
+
+Then in any Claude Code session: `/causal-memory` surfaces the skill, or
+just rely on the skill's trigger description.
+
+## Uninstall
+
+```bash
+./uninstall.sh
+```
+
+## Notes
+
+- The DB defaults to `~/.local/share/causal-memory/causal.db` (shared with
+  other integrations). Override with `CAUSAL_MEMORY_DB`.
+- Embedding / LLM features read `CAUSAL_MEMORY_EMBED_*` / `CAUSAL_MEMORY_LLM_*`
+  (configure once via `causal-memory setconfig`); without them retrieval
+  degrades gracefully to BM25.
+- HTTP transport alternative: `causal-memory http --port 9938` +
+  `claude mcp add --transport http causal-memory http://127.0.0.1:9938/mcp`
+  (set `CAUSAL_MEMORY_HTTP_AUTH_TOKEN` before exposing the port).

--- a/integrations/claude-code/install.sh
+++ b/integrations/claude-code/install.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Register causal-memory as a user-scope Claude Code MCP server + install
+# the activation skill. Idempotent: re-running refreshes both.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+BIN="${BIN:-$REPO_ROOT/target/release/causal-memory}"
+SKILL_SRC="$REPO_ROOT/skills/causal-memory/SKILL.md"
+SKILL_DST="$HOME/.claude/skills/causal-memory/SKILL.md"
+
+if [[ ! -x "$BIN" ]]; then
+  echo "binary not found: $BIN" >&2
+  echo "build it first: cargo build --release -p causal-memory-cli" >&2
+  exit 1
+fi
+
+# 1. MCP server (user scope = every project). Remove a stale entry first so
+#    re-running refreshes the command path cleanly.
+claude mcp remove causal-memory --scope user >/dev/null 2>&1 || true
+claude mcp add --scope user causal-memory -- "$BIN"
+echo "✓ MCP server registered (user scope): causal-memory → $BIN"
+
+# 2. Activation skill.
+mkdir -p "$(dirname "$SKILL_DST")"
+cp "$SKILL_SRC" "$SKILL_DST"
+echo "✓ skill installed: $SKILL_DST"
+
+echo
+echo "Verify:  claude mcp list   (causal-memory must connect)"
+echo "DB:      ~/.local/share/causal-memory/causal.db (CAUSAL_MEMORY_DB to override)"

--- a/integrations/claude-code/uninstall.sh
+++ b/integrations/claude-code/uninstall.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Remove the causal-memory MCP server registration and skill from Claude Code.
+set -euo pipefail
+
+claude mcp remove causal-memory --scope user >/dev/null 2>&1 || true \
+  && echo "✓ MCP server removed" || echo "(no registration found)"
+rm -f "$HOME/.claude/skills/causal-memory/SKILL.md" \
+  && echo "✓ skill removed" || true
+rmdir "$HOME/.claude/skills/causal-memory" 2>/dev/null || true
+echo "The memory DB (~/.local/share/causal-memory/) is kept."

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -1,0 +1,42 @@
+# Codex CLI integration
+
+Causal memory as a Codex MCP server + global `AGENTS.md` activation
+guidance.
+
+## What it wires up
+
+1. **MCP server**: `codex mcp add causal-memory -- <bin>` (stdio). All 17
+   tools, same as every other surface.
+2. **AGENTS.md guidance**: a causal-memory section appended to
+   `~/.codex/AGENTS.md` (Codex's global guidance file) teaching WHEN to
+   call the tools — including the Rung-3 activation rules: record
+   `context` when options were weighed, `counterfactual_query` when
+   choosing between two options, `prediction_report` periodically.
+
+## Install
+
+```bash
+./install.sh            # uses target/release/causal-memory by default
+BIN=/other/path ./install.sh
+```
+
+Verify:
+
+```bash
+codex mcp list          # causal-memory must appear
+codex mcp get causal-memory
+```
+
+## Uninstall
+
+```bash
+./uninstall.sh          # removes the MCP entry + the AGENTS.md section
+```
+
+## Notes
+
+- Same shared DB as other integrations (`~/.local/share/causal-memory/
+  causal.db`), so lessons learned in Claude Code / kimi / Hermes are
+  visible to Codex and vice versa.
+- The AGENTS.md section is delimited by `<!-- causal-memory:start -->` /
+  `<!-- causal-memory:end -->` markers — safe to re-run, removes cleanly.

--- a/integrations/codex/install.sh
+++ b/integrations/codex/install.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Register causal-memory as a Codex MCP server + append the activation
+# guidance to ~/.codex/AGENTS.md. Idempotent: re-running refreshes both.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+BIN="${BIN:-$REPO_ROOT/target/release/causal-memory}"
+AGENTS="$HOME/.codex/AGENTS.md"
+START='<!-- causal-memory:start -->'
+END='<!-- causal-memory:end -->'
+
+if [[ ! -x "$BIN" ]]; then
+  echo "binary not found: $BIN" >&2
+  echo "build it first: cargo build --release -p causal-memory-cli" >&2
+  exit 1
+fi
+
+# 1. MCP server (remove first so re-runs refresh the command path).
+codex mcp remove causal-memory >/dev/null 2>&1 || true
+codex mcp add causal-memory -- "$BIN"
+echo "✓ MCP server registered: causal-memory → $BIN"
+
+# 2. AGENTS.md activation section (marker-delimited, replace-if-present).
+mkdir -p "$HOME/.codex"
+touch "$AGENTS"
+python3 - "$AGENTS" "$START" "$END" <<'PYEOF'
+import sys
+
+path, start, end = sys.argv[1], sys.argv[2], sys.argv[3]
+section = f"""{start}
+## Causal memory (MCP tools — use proactively, do not ask first)
+
+You have a persistent causal-memory store recording past decisions and
+their outcomes. It survives compaction and restarts.
+
+- **Before any non-trivial decision** (architecture, debugging approach,
+  library selection, deployment strategy): call `search_memory` with your
+  query (facts + causal lessons, fused). For risky or irreversible actions,
+  also call `intervention_query` on the action (safe / warning / danger).
+- **When choosing between two concrete options**: call
+  `counterfactual_query` with both option texts — recorded-outcome
+  comparison, same-context branches (natural experiments) when they exist,
+  and a logged falsifiable prediction.
+- **After acting and observing the result**: call `record_decision` with
+  `decision` / `outcome` / `relation` (caused / enabled / prevented /
+  no_effect) / `task_tag` / `confidence_source`, and **`context`** — a
+  short description of the situation (environment, constraints, key
+  parameters). Same task_tag + context ⇒ comparable branch; if you weighed
+  multiple options at this decision point, ALWAYS record the context.
+  Record surprising outcomes especially — those are the most valuable
+  lessons.
+- **Stable facts** (preferences, tech stack, config): `record_fact` with
+  `key` / `value` / `scope`; `replace_same_key: true` when superseding.
+- **When something fails unexpectedly**: `trace_cause` (single hop) /
+  `trace_cause_chain` (multi-hop root cause).
+- **When a recorded lesson turns out wrong**: `invalidate_decision`.
+- **Periodically**: `prediction_report` — accuracy of past counterfactual
+  verdicts per method / per task_tag; it keeps the advice honest.
+{end}
+"""
+text = open(path).read()
+if start in text and end in text:
+    pre, rest = text.split(start, 1)
+    _, post = rest.split(end, 1)
+    text = pre + section + post
+else:
+    text = text.rstrip() + ("\n\n" if text.strip() else "") + section + "\n"
+open(path, "w").write(text)
+PYEOF
+echo "✓ AGENTS.md guidance: $AGENTS"
+
+# 3. Native slash prompt: /causal-memory <task> (Codex custom prompts).
+PROMPT_SRC="$REPO_ROOT/plugins/codex/prompts/causal-memory.md"
+PROMPT_DST_DIR="$HOME/.codex/prompts"
+if [[ -f "$PROMPT_SRC" ]]; then
+  mkdir -p "$PROMPT_DST_DIR"
+  cp "$PROMPT_SRC" "$PROMPT_DST_DIR/causal-memory.md"
+  echo "✓ slash prompt installed: /causal-memory ($PROMPT_DST_DIR/causal-memory.md)"
+fi
+
+echo
+echo "Verify:  codex mcp list   (causal-memory must appear)"
+echo "DB:      ~/.local/share/causal-memory/causal.db (CAUSAL_MEMORY_DB to override)"

--- a/integrations/codex/uninstall.sh
+++ b/integrations/codex/uninstall.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Remove the causal-memory MCP entry and the AGENTS.md guidance section.
+set -euo pipefail
+
+AGENTS="$HOME/.codex/AGENTS.md"
+START='<!-- causal-memory:start -->'
+END='<!-- causal-memory:end -->'
+
+codex mcp remove causal-memory >/dev/null 2>&1 \
+  && echo "✓ MCP server removed" || echo "(no registration found)"
+
+if [[ -f "$AGENTS" ]] && grep -q "$START" "$AGENTS"; then
+  python3 - "$AGENTS" "$START" "$END" <<'PYEOF'
+import sys
+path, start, end = sys.argv[1], sys.argv[2], sys.argv[3]
+text = open(path).read()
+pre, rest = text.split(start, 1)
+_, post = rest.split(end, 1)
+open(path, "w").write(pre.rstrip() + ("\n" if pre.strip() else "") + post.lstrip("\n"))
+PYEOF
+  echo "✓ AGENTS.md section removed"
+else
+  echo "(no AGENTS.md section found)"
+fi
+rm -f "$HOME/.codex/prompts/causal-memory.md" \
+  && echo "✓ slash prompt removed" || true
+
+echo "The memory DB (~/.local/share/causal-memory/) is kept."

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "causal-memory",
+  "version": "0.9.3",
+  "description": "Persistent causal memory for Claude Code — decisions, outcomes, and lessons that survive compaction. Same-context counterfactuals (natural experiments), a falsifiable prediction ledger, and an activation skill that teaches when to recall and record.",
+  "author": {
+    "name": "JingxuanC"
+  },
+  "homepage": "https://github.com/JingxuanC/causal-memory"
+}

--- a/plugins/claude-code/.mcp.json
+++ b/plugins/claude-code/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "causal-memory": {
+    "type": "stdio",
+    "command": "causal-memory",
+    "args": [],
+    "env": {}
+  }
+}

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -1,0 +1,47 @@
+# causal-memory — Claude Code plugin
+
+Persistent causal memory for Claude Code: decisions, outcomes, and lessons
+recorded as typed causal edges that survive compaction and restarts — plus
+same-context counterfactuals (natural experiments), a falsifiable
+prediction ledger, and an activation skill that teaches when to recall and
+when to record.
+
+## What's inside
+
+| Component | What it does |
+|---|---|
+| `.mcp.json` | Registers the `causal-memory` MCP server (stdio, 17 tools) with the plugin |
+| `skills/causal-memory` | Activation skill: WHEN to search / intervene / counterfactual / record (with `context`) / report |
+| `commands/recall` | `/recall <task or decision>` — experience check before acting |
+| `commands/memory-report` | `/memory-report` — prediction-ledger calibration + memory inventory |
+
+## Prerequisites
+
+The plugin launches `causal-memory` from PATH:
+
+```bash
+pip install causal-memory        # wheel ships the MCP server binary
+```
+
+(or build from repo: `git clone https://github.com/JingxuanC/causal-memory
+&& cargo build --release -p causal-memory-cli` and put
+`target/release/causal-memory` on PATH — then optional `causal-memory
+setconfig EMBED_API=... / LLM_API=...` for semantic + LLM features;
+without them everything degrades gracefully to BM25.)
+
+## Install (from this repo's marketplace)
+
+```bash
+claude plugin marketplace add JingxuanC/causal-memory
+claude plugin install causal-memory@causal-memory
+```
+
+The DB lives at `~/.local/share/causal-memory/causal.db` by default
+(`CAUSAL_MEMORY_DB` to override) and is shared with every other
+causal-memory integration (Codex, kimi CLI, Hermes, Python) — lessons
+cross-pollinate across agents.
+
+## Memory hygiene
+
+- `causal-memory sleep` periodically consolidates (decay, pattern mining);
+  `causal-memory stats` shows fork density and prediction accuracy.

--- a/plugins/claude-code/commands/memory-report.md
+++ b/plugins/claude-code/commands/memory-report.md
@@ -1,0 +1,22 @@
+---
+allowed-tools: mcp__causal-memory__prediction_report, mcp__causal-memory__causal_directory, mcp__causal-memory__search_causal, mcp__causal-memory__search_memory, mcp__causal-memory__search_facts
+description: Calibration + inventory check of your causal memory (prediction ledger accuracy, what you know)
+disable-model-invocation: false
+---
+
+Report the health of this workspace's causal memory. Do exactly this:
+
+1. Call `prediction_report` and show the verdict — accuracy per method and
+   per task_tag, pending predictions. If the ledger is empty, say so and
+   explain (one sentence) that `counterfactual_query` verdicts become
+   falsifiable predictions that auto-resolve when either option is later
+   recorded.
+2. Call `causal_directory` (limit 10) and summarize what experience exists
+   as a compact bullet list (task_tag — the one-line lesson).
+3. Flag anything notable: task_tags with dense same-context branches
+   (forks make counterfactuals same-world), falsified predictions
+   (accuracy < 50% in a stratum means those lessons deserve
+   `invalidate_decision`), or stale pending predictions.
+
+Keep the whole report under 200 words. No preamble — start with the
+prediction ledger line.

--- a/plugins/claude-code/commands/recall.md
+++ b/plugins/claude-code/commands/recall.md
@@ -1,0 +1,28 @@
+---
+allowed-tools: mcp__causal-memory__search_memory, mcp__causal-memory__search_causal, mcp__causal-memory__search_facts, mcp__causal-memory__intervention_query, mcp__causal-memory__counterfactual_query
+description: Recall past experience relevant to a task or decision before acting on it
+argument-hint: <what you are about to do or decide>
+disable-model-invocation: false
+---
+
+Before acting on "$ARGUMENTS", recall everything relevant from causal
+memory:
+
+1. Call `search_memory` with "$ARGUMENTS" (fused facts + causal lessons).
+2. If any hit's task_tag looks like the current domain, call
+   `search_causal` restricted to that tag for depth.
+3. Judgment call, two concrete options in play? Call
+   `counterfactual_query` with BOTH option texts — same-context branches
+   (natural experiments) beat pooled statistics when they exist.
+4. Risky or irreversible action? Call `intervention_query` on it and heed
+   the safe/warning/danger label.
+
+Then answer, in this order:
+- **Relevant experience** (max 5 bullets: decision → outcome, with
+  task_tag and confidence)
+- **What it implies** for "$ARGUMENTS" (one short paragraph)
+- If you are about to record anything new afterwards, remember to pass
+  `context` on `record_decision` — especially when options were weighed.
+
+If memory holds nothing relevant, say so plainly and proceed; absence of
+evidence is not evidence of safety.

--- a/plugins/claude-code/skills/causal-memory/SKILL.md
+++ b/plugins/claude-code/skills/causal-memory/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: causal-memory
+description: Causal memory for agents — install/setup the causal-memory MCP server, then record decisions/outcomes and recall them before acting. Trigger when the user asks to install or set up causal-memory/agent memory, when causal-memory MCP tools are available and the agent faces a non-trivial decision (architecture, debugging approach, library/deployment choice), when something fails unexpectedly, or when the user asks to "remember" something.
+version: v1.1
+---
+
+# Causal Memory
+
+Causal memory records your past decisions and their outcomes as causal edges,
+so you learn from experience across sessions and survive context compaction.
+
+This skill has two parts:
+- **§1 Setup** — when the `record_decision` / `search_causal` MCP tools are
+  NOT available yet: install and configure them yourself.
+- **§2 Usage** — once the tools exist: the proactive recall/record loop.
+
+## 1. Setup (do this yourself, then tell the user to restart the client)
+
+1. **Install the package** (ships the full CLI as `causal-memory` on PATH):
+
+   ```bash
+   pip install causal-memory        # or: pipx install causal-memory
+   causal-memory --help | head -5   # verify the console script works
+   ```
+
+2. **Register it as an MCP server** in the user's client. Bare
+   `causal-memory` runs the stdio MCP server; the only env worth setting is
+   `CAUSAL_MEMORY_DB` (SQLite location, default `~/.causal-memory/causal.db`).
+
+   - **Claude Code** (CLI does the config for you):
+     ```bash
+     claude mcp add causal-memory -- causal-memory
+     ```
+   - **Cursor** — edit `~/.cursor/mcp.json` (merge into `mcpServers`):
+     ```json
+     { "mcpServers": { "causal-memory": { "command": "causal-memory" } } }
+     ```
+   - **Claude Desktop** — edit
+     `~/Library/Application Support/Claude/claude_desktop_config.json`
+     (same `mcpServers` shape as above).
+   - **Kimi Code** — add to `config.toml`:
+     ```toml
+     [mcp.servers.causal-memory]
+     command = "causal-memory"
+     ```
+
+   When editing JSON configs, merge — never overwrite the whole file.
+
+3. **Tell the user to restart the client** (MCP servers load at startup).
+   After restart, verify by calling `causal_directory` — an empty directory
+   is fine, an error means the server didn't come up.
+
+4. Optional shared/remote mode: `causal-memory http --port 9938` serves MCP
+   over Streamable HTTP at `/mcp` (multi-agent shared memory; bind
+   `--host 0.0.0.0` for non-localhost access, and set
+   `CAUSAL_MEMORY_HTTP_AUTH_TOKEN` to protect the observability routes
+   `/metrics` and `/debug/*` when the port is reachable beyond loopback).
+
+## 2. Usage (once the tools are available)
+
+**Do NOT ask the user before searching or recording — do it proactively.**
+
+The core loop (five tools cover 90% of usage):
+
+- **Before any non-trivial decision** (architecture, debugging approach,
+  library selection, deployment strategy): call `search_memory` (facts +
+  causal lessons, RRF-fused). For risky or irreversible actions, also call
+  `intervention_query` — it forward-simulates what similar past actions
+  caused (safe / warning / **danger**).
+- **When choosing between two concrete options**: `counterfactual_query`
+  with both option texts — recorded-outcome comparison, same-context
+  branches (natural experiments) when they exist, and a logged falsifiable
+  prediction that auto-resolves when either option is later recorded.
+- **After acting on a decision and observing the result**: call
+  `record_decision` with `decision`, `outcome`, `relation`
+  (caused / enabled / prevented / no_effect), `task_tag`,
+  `confidence_source`, and **`context`** — a short description of the
+  situation (environment, constraints, key parameters). Same task_tag +
+  context ⇒ comparable branch: this is the abduction substrate that makes
+  counterfactuals same-world. If you weighed multiple options at this
+  decision point, ALWAYS record the context. **Record surprising outcomes
+  especially — those are the most valuable lessons.**
+- **Stable facts** (preferences, tech stack, config): `record_fact` with
+  `key` / `value` / `scope`; `replace_same_key: true` when superseding.
+- **Failure postmortem**: `trace_cause` (single hop) /
+  `trace_cause_chain` (multi-hop root cause).
+- **Corrections**: `invalidate_decision` / `invalidate_pattern` (soft-delete,
+  kept for audit).
+- **Calibration check** (periodic): `prediction_report` — accuracy of past
+  counterfactual verdicts per method / per task_tag, plus pending
+  predictions.
+
+Keep `task_tag` consistent within a domain (e.g. `deployment`,
+`git-workflow`) — stratified pattern mining depends on it.
+
+## 3. Offline session extraction (CLI — backfill memory from past sessions)
+
+All four commands need an LLM: `CAUSAL_MEMORY_LLM_API` +
+`CAUSAL_MEMORY_LLM_KEY` (or `DEEPSEEK_API_KEY`). They write into the same
+`CAUSAL_MEMORY_DB` store the MCP server reads.
+
+Agent-native session files (`--agent grok|claude|kimi|codex`; kimi = OpenClaw
+format — kimi-code wire protocol 1.5 is NOT supported yet):
+
+- **`extract <session-file|dir>`** — the default choice. Batches 15 assistant
+  messages per LLM call; one call yields facts/preferences (→ fact layer)
+  AND lessons/causal edges in all layers. Cheapest full-coverage path.
+- **`judge <session-file|dir>`** — rule-based: pairs tool calls with their
+  results into decision→outcome edges, then LLM re-judges only the top-20
+  by confidence. Fewest LLM calls; causal edges only.
+- **`reasoning <session-file|dir> [max_messages]`** — one LLM call PER
+  assistant message, extracting decisions that never became tool calls
+  (rejected designs, debated trade-offs). Most thorough, most expensive
+  (calls = messages; default cap 30).
+
+Normalized conversation JSON (`{"date": "YYYY-MM-DD", "turns": [[speaker,
+message], ...]}` — hand-curated corpora, benchmark ingest):
+
+- **`distill <session.json|dir> [--dry-run]`** — same Distiller as
+  `extract`, for non-agent-native input. `--mode recurrence` switches to
+  the RecMem flow (embeddings + recurrence gate).
+
+Rule of thumb: backfilling an agent's history → `extract`; tight LLM budget
+→ `judge`; hunting "decisions that never became actions" → `reasoning`;
+own-format corpora → `distill`.
+
+**Unsupported session format? Convert it yourself.** The turns JSON is the
+universal interchange format — any agent can emit it and run `distill`, no
+Rust parser needed. `scripts/session_to_turns.py` is the reference
+converter (kimi-code wire v1.5 → turns JSON, ~60 lines) and its docstring
+IS the format spec: ordered `["speaker", message]` pairs, stitch streaming
+deltas, keep the assistant's reasoning prefixed `[think] `, inline
+outcome-bearing tool results. Adapt the `convert_*` function to your own
+session format (~1 hour of work), then `distill --dry-run` to verify.
+
+Full reference (16 tools): repo README "Sixteen MCP tools" —
+github.com/JingxuanC/causal-memory.

--- a/plugins/codex/prompts/causal-memory.md
+++ b/plugins/codex/prompts/causal-memory.md
@@ -1,0 +1,24 @@
+Recall past experience relevant to "$ARGUMENTS" from causal memory, then
+advise.
+
+Steps:
+
+1. Call `search_memory` with "$ARGUMENTS" (fused facts + causal lessons).
+2. If a hit's task_tag matches the current domain, call `search_causal`
+   restricted to it for depth.
+3. Two concrete options on the table? Call `counterfactual_query` with
+   BOTH option texts — same-context branches (natural experiments) outrank
+   pooled statistics when they exist. Risky/irreversible action? Call
+   `intervention_query` and heed the safe/warning/danger label.
+
+Answer with:
+- **Relevant experience** (≤5 bullets: decision → outcome, task_tag,
+  confidence)
+- **Implication** for "$ARGUMENTS" (short paragraph)
+
+If nothing relevant is stored, say so plainly and proceed — absence of
+evidence is not evidence of safety. After acting and observing the result,
+record the lesson with `record_decision`, passing `context` (environment,
+constraints, key parameters) — ALWAYS when multiple options were weighed:
+same task_tag + context becomes a comparable branch for future
+counterfactuals.


### PR DESCRIPTION
**重做版**（原安装脚本方案升级为原生插件）。

## Claude Code：原生插件（可市场分发）

仓库根新增 `.claude-plugin/marketplace.json` —— **本仓库自身就是一个插件市场**，用户两行安装：

```bash
claude plugin marketplace add JingxuanC/causal-memory
claude plugin install causal-memory@causal-memory
```

插件内容（`plugins/claude-code/`）：
- `.mcp.json`：stdio MCP server（从 PATH 拉起 `causal-memory`，前置 `pip install causal-memory` 或源码构建）
- 激活 skill（何时 search/intervention/counterfactual/record+context/report）
- `/recall <task>`：行动前的经验检查命令
- `/memory-report`：预测账本校准 + 记忆清单命令

**本地全链路实测**：marketplace add ✅ → install ✅ → details（3 skills + 1 MCP server，常驻 ~229 token）✅ → MCP **✔ Connected** ✅

## Codex CLI：原生形态（无插件市场，取最接近的）

- `plugins/codex/prompts/causal-memory.md` → `/causal-memory <task>` 自定义 prompt
- `integrations/codex` 安装器升级：MCP 注册 + AGENTS.md 段落 + slash prompt 三合一

## 兼容

`integrations/` 保留为不走市场的 fallback；所有表面共享同一 DB，教训跨 agent 交叉积累。

🤖 Generated with [Grok Build](https://grok.com/build)