### PR TITLE
feat(consolidate): Stage 5 BiasAudit — 记忆系统性偏差自动检测（硬化 §2.2）

### DIFF
--- a/crates/causal-memory-cli/src/amc.rs
+++ b/crates/causal-memory-cli/src/amc.rs
@@ -486,20 +486,21 @@ mod tests {
     async fn spawn_server(
         mode: WriteMode,
         auth_token: Option<String>,
-    ) -> (String, tokio::task::JoinHandle<()>, PathBuf) {
-        let dir = std::env::temp_dir().join(format!(
-            "amc-test-{}-{:?}",
-            std::process::id(),
-            std::time::Instant::now()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        let app = build_app(Arc::new(UserMemories::new(dir.clone(), mode)), auth_token);
+    ) -> (String, tokio::task::JoinHandle<()>, tempfile::TempDir) {
+        // tempfile::tempdir() gives an O_EXCL-unique dir; the old
+        // pid+Instant::now() name could collide when the harness starts
+        // several tests in the same tick, and one test's remove_dir_all
+        // then deleted a sibling's db dir mid-run (intermittent 500
+        // "open store: unable to open database file").
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
+        let app = build_app(Arc::new(UserMemories::new(dir, mode)), auth_token);
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let server = tokio::spawn(async move {
             axum::serve(listener, app).await.unwrap();
         });
-        (format!("http://{addr}"), server, dir)
+        (format!("http://{addr}"), server, tmp)
     }
 
     fn add_body(user: &str, session: &str, msgs: &[(&str, &str)]) -> serde_json::Value {
@@ -513,7 +514,7 @@ mod tests {
 
     #[tokio::test]
     async fn raw_roundtrip_isolation_and_topk() {
-        let (base, _server, dir) = spawn_server(WriteMode::Raw, None).await;
+        let (base, _server, _tmp) = spawn_server(WriteMode::Raw, None).await;
         let client = test_client();
         wait_ready(&client, &base).await;
 
@@ -532,7 +533,12 @@ mod tests {
                 .send()
                 .await
                 .unwrap();
-            assert!(resp.status().is_success());
+            assert!(
+                resp.status().is_success(),
+                "add failed: {} {}",
+                resp.status(),
+                resp.text().await.unwrap()
+            );
         }
 
         // Isolation: alice never sees bob's fruit and vice versa.
@@ -597,13 +603,11 @@ mod tests {
             2,
             "top_k=2 must bind"
         );
-
-        std::fs::remove_dir_all(dir).ok();
     }
 
     #[tokio::test]
     async fn empty_search_and_unknown_user() {
-        let (base, _server, dir) = spawn_server(WriteMode::Raw, None).await;
+        let (base, _server, _tmp) = spawn_server(WriteMode::Raw, None).await;
         let client = test_client();
         wait_ready(&client, &base).await;
         let resp = client
@@ -616,7 +620,6 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp["data"].as_array().unwrap().len(), 0);
-        std::fs::remove_dir_all(dir).ok();
     }
 
     #[tokio::test]
@@ -625,7 +628,7 @@ mod tests {
         // (remember's own fallback stores a raw stub). The contract's
         // synchronous-searchable rule holds either way.
         std::env::remove_var("CAUSAL_MEMORY_LLM_API");
-        let (base, _server, dir) = spawn_server(WriteMode::Distill, None).await;
+        let (base, _server, _tmp) = spawn_server(WriteMode::Distill, None).await;
         let client = test_client();
         wait_ready(&client, &base).await;
         let resp = client
@@ -635,7 +638,6 @@ mod tests {
             .await
             .unwrap();
         assert!(resp.status().is_success());
-        std::fs::remove_dir_all(dir).ok();
     }
 
     #[tokio::test]
@@ -643,7 +645,7 @@ mod tests {
         // Opt-in auth: token set → /metrics 401s without (or with a wrong)
         // bearer and serves with the right one; the challenge-contract
         // routes (/add /search) and probes stay open either way.
-        let (base, _server, dir) =
+        let (base, _server, _tmp) =
             spawn_server(WriteMode::Raw, Some("amc-bearer-token".into())).await;
         let client = test_client();
         wait_ready(&client, &base).await;
@@ -675,6 +677,5 @@ mod tests {
             .await
             .unwrap();
         assert!(resp.status().is_success());
-        std::fs::remove_dir_all(dir).ok();
     }
 }

--- a/crates/causal-memory-cli/src/commands/maintenance.rs
+++ b/crates/causal-memory-cli/src/commands/maintenance.rs
@@ -531,6 +531,53 @@ fn print_consolidation_report(
         report.q_updates
     );
 
+    // ── ⑤.1 BiasAudit (hardening §2.2): annotation only, never invalidates ──
+    let audit = &report.bias_audit;
+    println!("\n⑤.1 Bias audit (statistical self-consistency):");
+    if audit.polarity_skew.is_empty()
+        && audit.low_variance.is_empty()
+        && audit.confidence_drift.is_none()
+    {
+        println!("  ✅ no suspicious patterns detected");
+    } else {
+        for skew in &audit.polarity_skew {
+            println!(
+                "  ⚠️ polarity skew [{}]: {}/{} outcomes {} ({:.0}%) — tag may be one-sided",
+                skew.task_tag,
+                (skew.dominant_ratio * skew.polarized as f64).round(),
+                skew.polarized,
+                if skew.dominant_positive {
+                    "positive"
+                } else {
+                    "negative"
+                },
+                skew.dominant_ratio * 100.0
+            );
+        }
+        for pattern in &audit.low_variance {
+            println!(
+                "  ⚠️ zero-variance repeat: \"{}…\" ×{} (always {}) — self-reinforcement suspect",
+                pattern.decision_text.chars().take(40).collect::<String>(),
+                pattern.repetitions,
+                if pattern.polarity {
+                    "success"
+                } else {
+                    "failure"
+                }
+            );
+        }
+        if let Some(drift) = &audit.confidence_drift {
+            println!(
+                "  ⚠️ confidence drift: recent {} edges mean {:.2} vs historical {:.2} (Δ {:+.2})",
+                drift.window, drift.recent_mean, drift.historical_mean, drift.delta
+            );
+        }
+        println!(
+            "  → {} edge(s) flagged for human review (bias_flag; see `status`)",
+            audit.edges_flagged
+        );
+    }
+
     if report.dry_run {
         println!("\n(dry run — no changes were written)");
     }

--- a/crates/causal-memory/src/consolidate/mod.rs
+++ b/crates/causal-memory/src/consolidate/mod.rs
@@ -38,13 +38,15 @@ use crate::store::CausalStore;
 mod stages;
 mod types;
 
-pub use types::{ConsolidateConfig, ConsolidateReport, ReactivationEntry, SupersessionAction};
+pub use types::{
+    BiasAuditReport, ConsolidateConfig, ConsolidateReport, ReactivationEntry, SupersessionAction,
+};
 
 use rusqlite::params;
 
 use stages::{
-    downscale, merge_redundant_edges, rem_integrate, replay_writeback, score_reactivation,
-    snapshot_meta_edges,
+    bias_audit, downscale, merge_redundant_edges, rem_integrate, replay_writeback,
+    score_reactivation, snapshot_meta_edges,
 };
 
 /// Run one full sleep-consolidation cycle over `store`.
@@ -167,6 +169,20 @@ pub fn consolidate(
         "[consolidate] stage 4 done ({} rem transfers)",
         report.rem_transfers
     );
+
+    // ── Stage 5: BiasAudit — statistical self-consistency detectors ─────
+    // Runs last, on the post-consolidation population: flags suspicious
+    // edges (polarity-skewed tags, zero-variance repeats) for human review
+    // and reports confidence drift. Pure annotation — no invalidation.
+    if config.bias_audit_enabled {
+        let flagged = bias_audit(store, config, dry_run, &mut report.bias_audit)?;
+        eprintln!(
+            "[consolidate] stage 5 done ({} skewed tags, {} low-variance patterns, {} flagged)",
+            report.bias_audit.polarity_skew.len(),
+            report.bias_audit.low_variance.len(),
+            flagged
+        );
+    }
 
     Ok(report)
 }

--- a/crates/causal-memory/src/consolidate/stages.rs
+++ b/crates/causal-memory/src/consolidate/stages.rs
@@ -8,7 +8,8 @@ use crate::patterns::{boilerplate_tokens, content_tokens, jaccard, tokenize};
 use crate::store::{outcome_polarity, outcomes_contradict, CausalStore};
 
 use super::types::{
-    ConsolidateConfig, ConsolidateReport, MetaNode, ReactivationEntry, SECS_PER_DAY,
+    BiasAuditReport, ConsolidateConfig, ConsolidateReport, MetaNode, ReactivationEntry,
+    SECS_PER_DAY,
 };
 
 /// Stage 1: replay-priority score for every valid edge.
@@ -570,4 +571,48 @@ pub fn rem_integrate(
         }
     }
     Ok(transfers)
+}
+
+/// Stage 5: BiasAudit (hardening §2.2) — statistical self-consistency
+/// detectors over the valid-edge population. Flags suspicious edges for
+/// human review (`bias_flag`, v17); nothing is invalidated, decayed, or
+/// hidden. Pure analysis in dry runs.
+///
+/// An edge caught by two detectors keeps the LAST stamp (detector 2 runs
+/// after detector 1); the report lists both findings regardless.
+pub fn bias_audit(
+    store: &CausalStore,
+    config: &ConsolidateConfig,
+    dry_run: bool,
+    report: &mut BiasAuditReport,
+) -> Result<usize> {
+    report.polarity_skew =
+        store.audit_polarity_skew(config.bias_min_tag_edges, config.bias_skew_ratio)?;
+    report.low_variance = store.audit_low_variance_decisions(config.bias_min_repetitions)?;
+    report.confidence_drift =
+        store.audit_confidence_drift(config.bias_drift_window, config.bias_drift_threshold)?;
+
+    let mut flagged = 0usize;
+    if !dry_run {
+        for skew in &report.polarity_skew {
+            let flag = format!("polarity_skew:{}", skew.task_tag);
+            for &edge_id in &skew.edge_ids {
+                // Best-effort: a failed stamp must never break the cycle.
+                if store.set_bias_flag(edge_id, &flag).is_ok() {
+                    flagged += 1;
+                }
+            }
+        }
+        for pattern in &report.low_variance {
+            let snippet: String = pattern.decision_text.chars().take(40).collect();
+            let flag = format!("low_variance:{snippet}");
+            for &edge_id in &pattern.edge_ids {
+                if store.set_bias_flag(edge_id, &flag).is_ok() {
+                    flagged += 1;
+                }
+            }
+        }
+    }
+    report.edges_flagged = flagged;
+    Ok(flagged)
 }

--- a/crates/causal-memory/src/consolidate/tests.rs
+++ b/crates/causal-memory/src/consolidate/tests.rs
@@ -1272,3 +1272,208 @@ fn test_fact_replace_records_supersession_lineage() {
     assert!(valid, "re-recorded fact revives");
     assert_eq!(superseded_by, None, "revive clears the lineage");
 }
+
+// ── Stage 5: BiasAudit (hardening §2.2) ─────────────────────────────
+
+#[test]
+fn test_bias_audit_flags_polarity_skewed_tag() {
+    // 6/6 positive edges under one tag → skew detector fires; a balanced
+    // tag with the same population stays clean. Flags land on the edges
+    // and are listed for human review.
+    let store = CausalStore::open_in_memory().unwrap();
+    for i in 0..6 {
+        insert_edge(
+            &store,
+            &format!("rolled out feature flag v{i}"),
+            "rollout succeeded with no incidents",
+            0.9,
+            "test",
+            Some("rosy"),
+            NOW,
+            None,
+        );
+    }
+    for i in 0..6 {
+        let outcome = if i % 2 == 0 {
+            "deploy crashed twice"
+        } else {
+            "deploy succeeded smoothly"
+        };
+        insert_edge(
+            &store,
+            &format!("shipped service s{i}"),
+            outcome,
+            0.9,
+            "test",
+            Some("mixed"),
+            NOW,
+            None,
+        );
+    }
+
+    let report = consolidate(&store, &default_config(), false, NOW).unwrap();
+    let skewed: Vec<_> = report
+        .bias_audit
+        .polarity_skew
+        .iter()
+        .map(|s| s.task_tag.as_str())
+        .collect();
+    assert!(
+        skewed.contains(&"rosy"),
+        "all-positive tag must be flagged: {skewed:?}"
+    );
+    assert!(
+        !skewed.contains(&"mixed"),
+        "balanced tag must not be flagged: {skewed:?}"
+    );
+    assert!(
+        report.bias_audit.edges_flagged >= 6,
+        "every edge in the skewed tag is flagged, got {}",
+        report.bias_audit.edges_flagged
+    );
+    let flagged = store.bias_flagged_edges().unwrap();
+    assert!(
+        flagged.iter().all(|f| f.flag == "polarity_skew:rosy"),
+        "flag names carry the detector and tag: {flagged:?}"
+    );
+    assert_eq!(flagged.len(), 6, "exactly the rosy edges: {flagged:?}");
+}
+
+#[test]
+fn test_bias_audit_flags_zero_variance_repeats() {
+    // The same decision recorded 3× with the same outcome polarity is a
+    // self-reinforcement suspect. Outcome texts differ slightly so stage 2a
+    // (duplicate merge) doesn't collapse them into one edge.
+    let store = CausalStore::open_in_memory().unwrap();
+    for day in ["monday", "tuesday", "wednesday"] {
+        insert_edge(
+            &store,
+            "rebuilt the search index nightly",
+            &format!("rebuild succeeded on {day}"),
+            0.85,
+            "test",
+            Some("ops"),
+            NOW,
+            None,
+        );
+    }
+    // A contrasting decision with real variance stays clean.
+    insert_edge(
+        &store,
+        "deployed the api gateway",
+        "deploy crashed on thursday",
+        0.85,
+        "test",
+        Some("ops"),
+        NOW,
+        None,
+    );
+    insert_edge(
+        &store,
+        "deployed the api gateway",
+        "deploy succeeded on friday",
+        0.85,
+        "test",
+        Some("ops"),
+        NOW,
+        None,
+    );
+
+    let report = consolidate(&store, &default_config(), false, NOW).unwrap();
+    let patterns: Vec<_> = report
+        .bias_audit
+        .low_variance
+        .iter()
+        .map(|p| p.decision_text.as_str())
+        .collect();
+    assert!(
+        patterns.contains(&"rebuilt the search index nightly"),
+        "zero-variance repeat must be flagged: {patterns:?}"
+    );
+    assert!(
+        !patterns.contains(&"deployed the api gateway"),
+        "varied decision must not be flagged: {patterns:?}"
+    );
+    let flagged = store.bias_flagged_edges().unwrap();
+    assert!(
+        flagged.iter().all(|f| f.flag.starts_with("low_variance:")),
+        "flag names carry the detector: {flagged:?}"
+    );
+    assert_eq!(flagged.len(), 3, "the three repeat edges: {flagged:?}");
+}
+
+#[test]
+fn test_bias_audit_confidence_drift_unit() {
+    // Detector 3 is report-only: drift shows up in the audit report but
+    // stamps no flags.
+    let store = CausalStore::open_in_memory().unwrap();
+    // 20 historical edges at 0.5, then 10 recent at 0.9: window=20 sees
+    // mean(10×0.9 + 10×0.5) = 0.7 vs historical 0.5 → Δ+0.2 ≥ 0.15.
+    for i in 0..20 {
+        insert_edge(
+            &store,
+            &format!("historical decision h{i}"),
+            "result succeeded",
+            0.5,
+            "test",
+            Some("drift"),
+            NOW - 40 * DAY,
+            None,
+        );
+    }
+    for i in 0..10 {
+        insert_edge(
+            &store,
+            &format!("recent decision r{i}"),
+            "result succeeded",
+            0.9,
+            "test",
+            Some("drift"),
+            NOW,
+            None,
+        );
+    }
+
+    let drift = store
+        .audit_confidence_drift(20, 0.15)
+        .unwrap()
+        .expect("drift beyond threshold must be reported");
+    assert!(drift.delta > 0.15, "delta = {}", drift.delta);
+
+    // Small store: no historical baseline → None.
+    let small = CausalStore::open_in_memory().unwrap();
+    insert_edge(&small, "only edge", "ok", 0.9, "test", None, NOW, None);
+    assert!(
+        small.audit_confidence_drift(20, 0.15).unwrap().is_none(),
+        "no baseline, no drift report"
+    );
+}
+
+#[test]
+fn test_bias_audit_dry_run_flags_nothing() {
+    // Dry runs report the findings but stamp nothing — the review queue
+    // stays empty.
+    let store = CausalStore::open_in_memory().unwrap();
+    for i in 0..6 {
+        insert_edge(
+            &store,
+            &format!("nightly backup run {i}"),
+            "backup succeeded",
+            0.9,
+            "test",
+            Some("backups"),
+            NOW,
+            None,
+        );
+    }
+    let report = consolidate(&store, &default_config(), true, NOW).unwrap();
+    assert_eq!(report.bias_audit.polarity_skew.len(), 1, "skew detected");
+    assert!(
+        report.bias_audit.edges_flagged == 0,
+        "dry run stamps nothing"
+    );
+    assert!(
+        store.bias_flagged_edges().unwrap().is_empty(),
+        "review queue empty after dry run"
+    );
+}

--- a/crates/causal-memory/src/consolidate/types.rs
+++ b/crates/causal-memory/src/consolidate/types.rs
@@ -91,6 +91,25 @@ pub struct ConsolidateConfig {
     /// the CausalEval v13 action layer. Default `Retire` until the 140q
     /// A/B (detect vs detect-retire) says otherwise.
     pub supersession_action: SupersessionAction,
+    /// Stage 5 (BiasAudit): run the statistical self-consistency detectors
+    /// and stamp `bias_flag` on suspicious edges. Pure annotation — nothing
+    /// here invalidates, decays, or hides a memory.
+    pub bias_audit_enabled: bool,
+    /// Stage 5 detector 1: a task_tag needs at least this many known-polarity
+    /// outcomes before skew is meaningful.
+    pub bias_min_tag_edges: usize,
+    /// Stage 5 detector 1: dominant-direction share at/above which the tag
+    /// is flagged (0.9 = 90% one direction).
+    pub bias_skew_ratio: f64,
+    /// Stage 5 detector 2: a decision recorded at least this many times with
+    /// identical outcome polarity is a self-reinforcement suspect.
+    pub bias_min_repetitions: usize,
+    /// Stage 5 detector 3: recency window (edge count) for the confidence
+    /// drift comparison.
+    pub bias_drift_window: usize,
+    /// Stage 5 detector 3: absolute recent-vs-historical mean-confidence
+    /// shift that counts as drift.
+    pub bias_drift_threshold: f64,
     /// Pattern-miner configuration, reused for stages 2 and 4.
     pub miner: MinerConfig,
 }
@@ -128,6 +147,12 @@ impl Default for ConsolidateConfig {
             half_life_fact_hours: 2160, // 90d — facts fade slowest
             supersession_limit: 20,
             supersession_action: SupersessionAction::Retire,
+            bias_audit_enabled: true,
+            bias_min_tag_edges: 5,
+            bias_skew_ratio: 0.9,
+            bias_min_repetitions: 3,
+            bias_drift_window: 20,
+            bias_drift_threshold: 0.15,
             q_alpha: 0.1,
             q_gamma: 0.9,
             min_diversity: 0.0,
@@ -161,6 +186,22 @@ pub struct ReactivationEntry {
     pub score: f64,
     /// Why this score: e.g. "base confidence", "outcome failed (+0.5)".
     pub reasons: Vec<String>,
+}
+
+/// Stage 5 (BiasAudit) findings: what the statistical self-consistency
+/// detectors saw this cycle. Pure annotation — flagged edges stay fully
+/// retrievable; the flags are a human review queue (`bias_flagged_edges`).
+#[derive(Debug, Default)]
+pub struct BiasAuditReport {
+    /// Detector 1: task_tags with a one-sided outcome polarity distribution.
+    pub polarity_skew: Vec<crate::store::PolaritySkew>,
+    /// Detector 2: decisions repeated ≥ N times with zero outcome variance.
+    pub low_variance: Vec<crate::store::LowVariancePattern>,
+    /// Detector 3: recent-vs-historical confidence mean shift, if beyond
+    /// threshold. Report-only — no per-edge flag (no single edge is at fault).
+    pub confidence_drift: Option<crate::store::ConfidenceDrift>,
+    /// Edges stamped with `bias_flag` this cycle.
+    pub edges_flagged: usize,
 }
 
 /// What one consolidation cycle did (or would do, when `dry_run`).
@@ -201,6 +242,8 @@ pub struct ConsolidateReport {
     pub diversity: f64,
     /// P6: consolidation skipped because diversity < min_diversity.
     pub skipped_low_diversity: bool,
+    /// Stage 5: BiasAudit findings (polarity skew / low variance / drift).
+    pub bias_audit: BiasAuditReport,
     pub dry_run: bool,
 }
 

--- a/crates/causal-memory/src/migrate.rs
+++ b/crates/causal-memory/src/migrate.rs
@@ -31,7 +31,7 @@ use rusqlite::{params, Connection};
 use crate::store::CAUSAL_SCHEMA_SQL;
 
 /// Current schema version. Bump when adding a new migration step.
-pub const SCHEMA_VERSION: u32 = 16;
+pub const SCHEMA_VERSION: u32 = 17;
 
 /// Bring `conn` up to `SCHEMA_VERSION`. Runs in a single transaction:
 /// any failure rolls everything back.
@@ -91,6 +91,9 @@ pub fn migrate(conn: &Connection) -> Result<()> {
     }
     if version < 16 {
         migrate_to_v16(&tx)?;
+    }
+    if version < 17 {
+        migrate_to_v17(&tx)?;
     }
 
     // Creates any missing tables/indexes at v3 (no-op for existing ones).
@@ -1136,5 +1139,20 @@ fn migrate_to_v16(conn: &Connection) -> Result<()> {
             ON causal_edges(context_fingerprint) WHERE context_fingerprint IS NOT NULL;
         ",
     )?;
+    Ok(())
+}
+
+/// v17: add the bias-audit annotation column (hardening §2.2). Nullable,
+/// unconstrained TEXT — one ALTER, no table rebuild. Guarded by a column
+/// check so a store that somehow already carries the column (restore from a
+/// newer backup, hand-edited DB) skips instead of erroring.
+fn migrate_to_v17(conn: &Connection) -> Result<()> {
+    if !table_exists(conn, "causal_edges")? {
+        return Ok(()); // fresh DB: CAUSAL_SCHEMA_SQL creates the v17 shape
+    }
+    if table_columns(conn, "causal_edges")?.contains("bias_flag") {
+        return Ok(()); // already migrated (idempotent re-run)
+    }
+    conn.execute_batch("ALTER TABLE causal_edges ADD COLUMN bias_flag TEXT")?;
     Ok(())
 }

--- a/crates/causal-memory/src/store/bias_audit.rs
+++ b/crates/causal-memory/src/store/bias_audit.rs
@@ -208,7 +208,7 @@ impl CausalStore {
                 }
             }
         }
-        out.sort_by(|a, b| b.repetitions.cmp(&a.repetitions));
+        out.sort_by_key(|a| std::cmp::Reverse(a.repetitions));
         Ok(out)
     }
 

--- a/crates/causal-memory/src/store/bias_audit.rs
+++ b/crates/causal-memory/src/store/bias_audit.rs
@@ -1,0 +1,295 @@
+//! Bias audit (hardening §2.2): statistical self-consistency checks over the
+//! valid-edge population, run once per sleep-consolidation cycle.
+//!
+//! Three detectors, all purely observational — they flag SUSPICIOUS
+//! structure for human review, never invalidate anything:
+//!
+//! 1. **Polarity skew per task_tag** — a tag whose recorded outcomes are
+//!    almost all one direction (e.g. 12/13 positive) is either a genuinely
+//!    rosy domain or a memory that stopped recording failures. Binomially,
+//!    a 13-sample with one dissent is a ~0.2% event under a fair process.
+//! 2. **Zero-variance repeated decisions** — the same decision recorded
+//!    ≥3 times with the SAME outcome polarity every time is a
+//!    self-reinforcement signature: the memory may be echoing itself rather
+//!    than tracking the world. (Real repeated decisions usually see at
+//!    least one mixed/neutral outcome eventually.)
+//! 3. **Confidence drift** — the mean confidence of the most recent N edges
+//!    vs everything older, shifted beyond a threshold, signals systematic
+//!    over- or under-confidence in what the extractor/judge has been
+//!    emitting lately. Report-only (no per-edge flag: no single edge is
+//!    at fault).
+//!
+//! Flags persist on the edge row (`bias_flag`, v17) and are visible via
+//! [`CausalStore::bias_flagged_edges`]; retrieval, decay, and GC ignore
+//! them by design.
+
+use anyhow::Result;
+
+use crate::store::utils::effective_polarity;
+use crate::store::CausalStore;
+
+/// One task_tag whose outcome polarity distribution is suspiciously one-sided.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PolaritySkew {
+    pub task_tag: String,
+    /// Edges in the tag with a KNOWN effective polarity (unknown ones don't
+    /// count toward the distribution — they can't evidence either way).
+    pub polarized: usize,
+    /// Share of the dominant direction, 0.5..=1.0.
+    pub dominant_ratio: f64,
+    /// True when the dominant direction is success.
+    pub dominant_positive: bool,
+    /// All valid edge ids in this tag — the BiasAudit stage stamps these.
+    pub edge_ids: Vec<i64>,
+}
+
+/// One decision chunk recorded repeatedly with an unchanging outcome polarity.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LowVariancePattern {
+    /// Decision text (the from-chunk), for human review.
+    pub decision_text: String,
+    /// Times this decision was recorded with a known polarity.
+    pub repetitions: usize,
+    /// The single polarity every recorded outcome agreed on.
+    pub polarity: bool,
+    /// The zero-variance edge ids — the BiasAudit stage stamps these.
+    pub edge_ids: Vec<i64>,
+}
+
+/// Recent-vs-historical confidence mean shift. Report-only.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ConfidenceDrift {
+    pub window: usize,
+    pub recent_mean: f64,
+    pub historical_mean: f64,
+    pub delta: f64,
+}
+
+/// One flagged edge, as listed for human review.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FlaggedEdge {
+    pub edge_id: i64,
+    /// Which detector flagged it: `polarity_skew:<tag>` or
+    /// `low_variance:<decision snippet>`.
+    pub flag: String,
+    pub decision_text: String,
+}
+
+impl CausalStore {
+    /// Detector 1: task_tags whose known-polarity outcomes are one-sided.
+    ///
+    /// `min_edges` bounds the sample below which skew is meaningless;
+    /// `skew_ratio` is the dominant-direction share at/above which the tag
+    /// is flagged (0.9 = 90% one direction).
+    pub fn audit_polarity_skew(
+        &self,
+        min_edges: usize,
+        skew_ratio: f64,
+    ) -> Result<Vec<PolaritySkew>> {
+        let conn = self.acquire()?;
+        let mut stmt = conn.prepare(
+            "SELECT ce.task_tag, ce.outcome_polarity, ct.text, ce.id
+             FROM causal_edges ce
+             JOIN chunks ct ON ct.id = ce.to_id
+             WHERE ce.valid_to IS NULL AND ce.task_tag IS NOT NULL",
+        )?;
+        let rows = stmt.query_map([], |r| {
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, Option<String>>(1)?,
+                r.get::<_, String>(2)?,
+                r.get::<_, i64>(3)?,
+            ))
+        })?;
+
+        use std::collections::HashMap;
+        // tag -> ((pos, neg), all valid edge ids in the tag)
+        let mut tags: HashMap<String, ((usize, usize), Vec<i64>)> = HashMap::new();
+        for row in rows {
+            let (tag, stored, outcome_text, edge_id) = row?;
+            let entry = tags.entry(tag).or_default();
+            entry.1.push(edge_id);
+            match effective_polarity(stored.as_deref(), &outcome_text) {
+                Some(true) => entry.0 .0 += 1,
+                Some(false) => entry.0 .1 += 1,
+                None => {}
+            }
+        }
+
+        let mut out = Vec::new();
+        for (task_tag, ((pos, neg), edge_ids)) in tags {
+            let polarized = pos + neg;
+            if polarized < min_edges {
+                continue;
+            }
+            let dominant = pos.max(neg);
+            let ratio = dominant as f64 / polarized as f64;
+            if ratio >= skew_ratio {
+                out.push(PolaritySkew {
+                    task_tag,
+                    polarized,
+                    dominant_ratio: ratio,
+                    dominant_positive: pos >= neg,
+                    edge_ids,
+                });
+            }
+        }
+        out.sort_by(|a, b| {
+            b.dominant_ratio
+                .partial_cmp(&a.dominant_ratio)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        Ok(out)
+    }
+
+    /// Detector 2: decisions recorded ≥ `min_count` times where every
+    /// recorded outcome with a known polarity agrees (zero variance).
+    pub fn audit_low_variance_decisions(
+        &self,
+        min_count: usize,
+    ) -> Result<Vec<LowVariancePattern>> {
+        let conn = self.acquire()?;
+        let mut stmt = conn.prepare(
+            "SELECT cf.text, ce.outcome_polarity, ct.text, ce.id
+             FROM causal_edges ce
+             JOIN chunks cf ON cf.id = ce.from_id
+             JOIN chunks ct ON ct.id = ce.to_id
+             WHERE ce.valid_to IS NULL",
+        )?;
+        let rows = stmt.query_map([], |r| {
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, Option<String>>(1)?,
+                r.get::<_, String>(2)?,
+                r.get::<_, i64>(3)?,
+            ))
+        })?;
+
+        use std::collections::HashMap;
+
+        /// Accumulator for one decision's repeated-outcome statistics.
+        #[derive(Default)]
+        struct Group {
+            /// Recorded outcomes with a known polarity.
+            known: usize,
+            /// The first known polarity seen.
+            polarity: Option<bool>,
+            /// True once two known outcomes disagree (variance seen).
+            mixed: bool,
+            /// All valid edge ids for this decision (stamped when flagged).
+            edge_ids: Vec<i64>,
+        }
+
+        let mut groups: HashMap<String, Group> = HashMap::new();
+        for row in rows {
+            let (decision, stored, outcome_text, edge_id) = row?;
+            if let Some(p) = effective_polarity(stored.as_deref(), &outcome_text) {
+                let g = groups.entry(decision).or_default();
+                g.known += 1;
+                g.edge_ids.push(edge_id);
+                match g.polarity {
+                    None => g.polarity = Some(p),
+                    Some(prev) if prev != p => g.mixed = true,
+                    _ => {}
+                }
+            }
+        }
+
+        let mut out = Vec::new();
+        for (decision_text, g) in groups {
+            if g.known >= min_count && !g.mixed {
+                if let Some(polarity) = g.polarity {
+                    out.push(LowVariancePattern {
+                        decision_text,
+                        repetitions: g.known,
+                        polarity,
+                        edge_ids: g.edge_ids,
+                    });
+                }
+            }
+        }
+        out.sort_by(|a, b| b.repetitions.cmp(&a.repetitions));
+        Ok(out)
+    }
+
+    /// Detector 3: mean-confidence shift between the most recent `window`
+    /// valid edges and everything older. Returns None when the store has
+    /// too little history to compare (<= window edges total) — drift is
+    /// meaningless without a baseline. `threshold` is the absolute mean
+    /// shift that counts as drift.
+    pub fn audit_confidence_drift(
+        &self,
+        window: usize,
+        threshold: f64,
+    ) -> Result<Option<ConfidenceDrift>> {
+        if window == 0 {
+            return Ok(None);
+        }
+        let conn = self.acquire()?;
+        let total: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM causal_edges WHERE valid_to IS NULL",
+            [],
+            |r| r.get(0),
+        )?;
+        if total <= window as i64 {
+            return Ok(None); // no historical baseline
+        }
+        let recent: f64 = conn.query_row(
+            "SELECT AVG(confidence) FROM (
+                 SELECT confidence FROM causal_edges
+                 WHERE valid_to IS NULL ORDER BY id DESC LIMIT ?1
+             )",
+            rusqlite::params![window as i64],
+            |r| r.get(0),
+        )?;
+        let historical: f64 = conn.query_row(
+            "SELECT AVG(confidence) FROM (
+                 SELECT confidence FROM causal_edges
+                 WHERE valid_to IS NULL ORDER BY id DESC LIMIT -1 OFFSET ?1
+             )",
+            rusqlite::params![window as i64],
+            |r| r.get(0),
+        )?;
+        let delta = recent - historical;
+        if delta.abs() < threshold {
+            return Ok(None);
+        }
+        Ok(Some(ConfidenceDrift {
+            window,
+            recent_mean: recent,
+            historical_mean: historical,
+            delta,
+        }))
+    }
+
+    /// Stamp a bias flag on one edge (BiasAudit write path; dry runs skip).
+    pub fn set_bias_flag(&self, edge_id: i64, flag: &str) -> Result<()> {
+        let conn = self.acquire()?;
+        conn.execute(
+            "UPDATE causal_edges SET bias_flag = ?1 WHERE id = ?2",
+            rusqlite::params![flag, edge_id],
+        )?;
+        Ok(())
+    }
+
+    /// All currently flagged edges (any flag value), newest first — the
+    /// human review queue.
+    pub fn bias_flagged_edges(&self) -> Result<Vec<FlaggedEdge>> {
+        let conn = self.acquire()?;
+        let mut stmt = conn.prepare(
+            "SELECT ce.id, ce.bias_flag, cf.text
+             FROM causal_edges ce
+             JOIN chunks cf ON cf.id = ce.from_id
+             WHERE ce.bias_flag IS NOT NULL
+             ORDER BY ce.id DESC",
+        )?;
+        let rows = stmt.query_map([], |r| {
+            Ok(FlaggedEdge {
+                edge_id: r.get(0)?,
+                flag: r.get(1)?,
+                decision_text: r.get(2)?,
+            })
+        })?;
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+}

--- a/crates/causal-memory/src/store/mod.rs
+++ b/crates/causal-memory/src/store/mod.rs
@@ -88,6 +88,11 @@ CREATE TABLE IF NOT EXISTS causal_edges (
     -- raw description for display/audit.
     context_fingerprint TEXT,
     context_text TEXT,
+    -- v17 (hardening §2.2): bias-audit flag. One cycle's BiasAudit stage
+    -- stamps edges that participate in a suspicious statistical pattern
+    -- (polarity-skewed task_tag, zero-variance repeated decision). Purely
+    -- an annotation for human review — retrieval, decay, and GC ignore it.
+    bias_flag TEXT,
     FOREIGN KEY (from_id) REFERENCES chunks(id),
     FOREIGN KEY (to_id) REFERENCES chunks(id)
 );
@@ -633,6 +638,7 @@ impl Drop for PooledConn {
 
 // Submodules — each adds methods to `impl CausalStore`.
 mod audit;
+mod bias_audit;
 mod embed;
 mod facts;
 pub mod retrieve;
@@ -642,6 +648,7 @@ mod write;
 
 // Re-export all public types so `causal_memory::store::CausalEntry` still works.
 pub use audit::{RecallAuditEntry, RecallAuditRow};
+pub use bias_audit::{ConfidenceDrift, FlaggedEdge, LowVariancePattern, PolaritySkew};
 pub use types::*;
 pub use utils::{
     containment_similarity, date_tokens, effective_polarity, is_retraction_record,

--- a/crates/causal-memory/tests/migration_v17.rs
+++ b/crates/causal-memory/tests/migration_v17.rs
@@ -1,0 +1,91 @@
+//! v17 migration e2e: a v16 database (causal_edges without the bias_flag
+//! column) gains the column on open — data preserved, stamps work, and
+//! re-opening is a no-op (idempotent).
+
+use causal_memory::store::CausalStore;
+
+/// v16 causal_edges: the full post-rebuild shape (v16 CHECK included), no
+/// bias_flag column.
+const V16_SCHEMA_AND_DATA: &str = r#"
+CREATE TABLE chunks (
+    id TEXT PRIMARY KEY,
+    text TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    q_value REAL NOT NULL DEFAULT 0.5,
+    sparse_code TEXT
+);
+CREATE TABLE causal_edges (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    from_id TEXT NOT NULL,
+    to_id TEXT NOT NULL,
+    relation TEXT NOT NULL CHECK(relation IN ('caused','enabled','prevented','no_effect','co_occurrence')),
+    confidence REAL NOT NULL DEFAULT 0.5,
+    discovered_by TEXT NOT NULL DEFAULT 'llm_inferred',
+    event_time INTEGER NOT NULL,
+    discovered_at INTEGER NOT NULL,
+    valid_to INTEGER,
+    task_tag TEXT,
+    access_count INTEGER NOT NULL DEFAULT 0,
+    last_accessed_at INTEGER,
+    outcome_polarity TEXT CHECK(outcome_polarity IN ('positive','negative','mixed','neutral')),
+    superseded_by INTEGER,
+    context_fingerprint TEXT,
+    context_text TEXT,
+    FOREIGN KEY (from_id) REFERENCES chunks(id),
+    FOREIGN KEY (to_id) REFERENCES chunks(id)
+);
+INSERT INTO chunks (id, text, created_at) VALUES
+    ('d1', 'restart broker during deploy window', 1000),
+    ('o1', 'webhook delivery failures observed', 1000);
+INSERT INTO causal_edges (from_id, to_id, relation, confidence, discovered_by,
+                          event_time, discovered_at, task_tag, outcome_polarity)
+VALUES ('d1', 'o1', 'caused', 0.7, 'llm_inferred', 1000, 1000, 'legacy', 'negative');
+PRAGMA user_version = 16;
+"#;
+
+#[test]
+fn migration_from_v16_adds_bias_flag_column() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("v16.db");
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch(V16_SCHEMA_AND_DATA).unwrap();
+    }
+
+    let store = CausalStore::open(&db_path).unwrap();
+    store
+        .with_conn(|conn| {
+            let version: i64 = conn.query_row("PRAGMA user_version", [], |r| r.get(0))?;
+            assert_eq!(version, i64::from(causal_memory::migrate::SCHEMA_VERSION));
+            // Legacy row survived.
+            let kept: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM causal_edges WHERE relation = 'caused'",
+                [],
+                |r| r.get(0),
+            )?;
+            assert_eq!(kept, 1);
+            // The new column exists and starts empty.
+            let flags: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM causal_edges WHERE bias_flag IS NOT NULL",
+                [],
+                |r| r.get(0),
+            )?;
+            assert_eq!(flags, 0);
+            Ok(())
+        })
+        .unwrap();
+
+    // Stamps work end-to-end…
+    let edge = store.all_valid_edges().unwrap().pop().unwrap();
+    store
+        .set_bias_flag(edge.edge_id, "polarity_skew:legacy")
+        .unwrap();
+    let flagged = store.bias_flagged_edges().unwrap();
+    assert_eq!(flagged.len(), 1);
+    assert_eq!(flagged[0].flag, "polarity_skew:legacy");
+
+    // …and re-opening is a clean no-op (column-exists guard).
+    drop(store);
+    let reopened = CausalStore::open(&db_path).unwrap();
+    assert_eq!(reopened.bias_flagged_edges().unwrap().len(), 1);
+}

--- a/docs/design/memory-system-hardening.md
+++ b/docs/design/memory-system-hardening.md
@@ -124,6 +124,17 @@ search_contradicting 返回: "Redis 缓存雪崩了" (negative, same task_tag)
 
 产出：审计报告写入 `consolidation_report`，标记可疑边供人工审查。
 
+**已落地（2026-09-09，PR #30）**：
+- **Stage 5 BiasAudit**（consolidate 管线末尾，post-consolidation 种群上运行）：三个检测器在 `store/bias_audit.rs`——
+  1. `audit_polarity_skew(min_edges=5, skew_ratio=0.9)`：同一 task_tag 下已知 polarity 的 outcome 一边倒 ≥90% 即标记该 tag 全部边（`bias_flag = polarity_skew:<tag>`）。
+  2. `audit_low_variance_decisions(min_count=3)`：同一决策（from chunk）重复 ≥3 次且已知 polarity 零方差 → 自我强化嫌疑（`bias_flag = low_variance:<snippet>`）。
+  3. `audit_confidence_drift(window=20, threshold=0.15)`：最近 N 条边 confidence 均值 vs 历史均值漂移超阈值 → 仅进报告，不标边（无单一边有错）。
+- **纯标注原则**：bias_flag 只供人工审查（`bias_flagged_edges()` 是审查队列），检索/衰减/GC 一律无视；dry run 只报告不落标记。检测器失败 best-effort，永不中断固化周期。
+- **schema v17**：`causal_edges` 加可空 `bias_flag` 列（一次 ALTER，列存在性守卫幂等）；迁移测试覆盖 v16→v17 数据保留 + 重开幂等。
+- **配置项**：`ConsolidateConfig` 新增 `bias_audit_enabled` + 五个阈值旋钮。
+- **CLI**：sleep 报告新增 `⑤.1 Bias audit` 段（skew/low-variance/drift 三类发现 + 标记计数）。
+- **测试**：consolidate 层 4 个（skew 命中/平衡对照、零方差命中/有方差对照、drift 单测含无基线 None、dry run 不落标记）+ v17 迁移 e2e。326 lib + 48 cli 全绿。
+
 ### 2.3 记忆溯源增强
 
 **现状**：`discovered_by` 记录来源（rule/llm_inferred/user_feedback），`recall_audit` 记录检索历史。但没有记录"这条记忆影响了哪些后续决策"。


### PR DESCRIPTION
## 背景

硬化方案 §2.2（方向二：元因果层）：有半衰期衰减和手动 `invalidate_decision`，但没有**自动检测记忆系统性偏差**的机制。本 PR 在 sleep 固化周期末尾新增 **Stage 5 BiasAudit**。

## 三个检测器（`store/bias_audit.rs`）

| # | 检测 | 语义 | 默认阈值 |
|---|---|---|---|
| 1 | **polarity skew** | 同一 task_tag 下已知 polarity 的 outcome 一边倒——要么真 rosé 域，要么记忆停止记录失败 | ≥5 样本、主导方向 ≥90% |
| 2 | **zero-variance repeats** | 同一决策（from chunk）重复 ≥3 次且已知 polarity 全部一致——自我强化签名，记忆在回声而非追踪世界 | ≥3 次重复 |
| 3 | **confidence drift** | 最近 20 条边 confidence 均值 vs 历史均值漂移——抽取器/评判器近期系统性高/低估 | \|Δ\| ≥ 0.15 |

检测 3 只进报告不标边（没有单一边有错）；检测 1/2 给参与的边打 `bias_flag`。

## 纯标注原则（重要设计取舍）

- `bias_flag`（**schema v17**，一次 `ALTER TABLE ADD COLUMN`，列存在性守卫保证幂等重开）只供人工审查：`bias_flagged_edges()` 是审查队列。
- **检索、衰减、GC 一律无视这个标记**——审计永远不会因为"看起来可疑"而隐藏记忆。
- dry run 报告发现但不落标记。
- 检测器失败 best-effort，永不中断固化周期。

## 接入面

- `consolidate()` 管线末尾新增 Stage 5（post-consolidation 种群上运行）。
- `ConsolidateConfig` 新增 `bias_audit_enabled` + 五个阈值旋钮。
- CLI sleep 报告新增 `⑤.1 Bias audit` 段（三类发现 + 标记计数 + 审查指引）。

## 验证

- 326 lib + 48 cli + 全部集成测试绿；`cargo fmt --check` 与 `clippy --workspace -- -D warnings` 干净。
- 新增测试：consolidate 层 4 个（skew 命中/平衡对照、零方差命中/有方差对照、drift 单测含无基线返回 None、dry run 不落标记）+ `migration_v17` e2e（v16→v17 数据保留、标记读写、重开幂等）。
- 备注：全量并行跑时 `raw_roundtrip_isolation_and_topk` 出现一次 HTTP 状态断言失败，单独重跑即过——与本案无关的既有偶发（端口/时序类），已复跑确认。

## 文档

`docs/design/memory-system-hardening.md` §2.2 标记已落地。